### PR TITLE
defect: #69 Item Window Will not Open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "scripts": {

--- a/src/module.json
+++ b/src/module.json
@@ -1,7 +1,7 @@
 {
   "id": "fabricate",
   "title": "Fabricate",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A system-agnostic, flexible crafting module for FoundryVTT",
   "authors": [
     {

--- a/src/scripts/interface/apps/CraftingSystemManagerApp.ts
+++ b/src/scripts/interface/apps/CraftingSystemManagerApp.ts
@@ -60,8 +60,15 @@ class CraftingSystemManagerApp extends FormApplication {
             this._selectedSystem = Array.from(craftingSystems.values())[0];
         }
         await this._selectedSystem?.loadPartDictionary();
+        const systems = Array.from(craftingSystems.values())
+            .sort((left,right) => Number(right.locked) - Number(left.locked));
+        if (!this._selectedSystem) {
+            return {
+                craftingSystems: systems
+            }
+        }
         return {
-            craftingSystems: Array.from(craftingSystems.values()),
+            craftingSystems: systems,
             selectedSystem: {
                 id: this._selectedSystem.id,
                 name: this._selectedSystem.details.name,

--- a/src/scripts/system_definitions/AlchemistsSuppliesV16.ts
+++ b/src/scripts/system_definitions/AlchemistsSuppliesV16.ts
@@ -458,4 +458,9 @@ const SYSTEM_DEFINITION: CraftingSystemJson = {
     }
 }
 
-export {SYSTEM_DEFINITION}
+const SYSTEM_DATA = {
+    definition: SYSTEM_DEFINITION,
+    gameSystem: "dnd5e"
+}
+
+export {SYSTEM_DATA}

--- a/test/AlchemistsSuppliesIntegration.test.ts
+++ b/test/AlchemistsSuppliesIntegration.test.ts
@@ -3,7 +3,7 @@ import {beforeEach, describe, expect, jest, test} from '@jest/globals';
 import {CraftingSystemFactory} from "../src/scripts/system/CraftingSystemFactory";
 import {CraftingSystem} from "../src/scripts/system/CraftingSystem";
 import * as Sinon from "sinon";
-import {SYSTEM_DEFINITION as AlchemistsSupplies} from "../src/scripts/system_definitions/AlchemistsSuppliesV16"
+import {SYSTEM_DATA as AlchemistsSupplies} from "../src/scripts/system_definitions/AlchemistsSuppliesV16"
 import {StubDocumentManager} from "./stubs/StubDocumentManager";
 import {Combination} from "../src/scripts/common/Combination";
 
@@ -18,7 +18,7 @@ describe('A Crafting System Factory', () => {
 
     test('should create a new Crafting System from a valid specification', async () => {
 
-        const systemSpec = AlchemistsSupplies;
+        const systemSpec = AlchemistsSupplies.definition;
 
         const craftingSystemFactory: CraftingSystemFactory = new CraftingSystemFactory({
             documentManager: StubDocumentManager.forPartDefinitions({

--- a/test/SystemRegistry.test.ts
+++ b/test/SystemRegistry.test.ts
@@ -214,6 +214,7 @@ describe("integration test", () => {
         const underTest = new DefaultSystemRegistry({
             settingManager: fabricateSettingsManager,
             craftingSystemFactory,
+            gameSystem: "dnd5e",
             errorDecisionProvider: () => Promise.resolve(ErrorDecisionType.RETAIN)
         });
 


### PR DESCRIPTION
## Description

Closes #69 

- filters out embedded crafting systems that have a dependency on an inactive game system
- purges embedded systems from settings on startup
- if the system is present, the embedded system data is written back to the settings value when the crafting system manager is rendered. I'll open another issue for this