### PR TITLE
refactor: Handle missing items causing systems not to load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "scripts": {

--- a/src/module.json
+++ b/src/module.json
@@ -1,7 +1,7 @@
 {
   "id": "fabricate",
   "title": "Fabricate",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A system-agnostic, flexible crafting module for FoundryVTT",
   "authors": [
     {

--- a/src/scripts/interface/apps/EditCraftingSystemDetailDialog.ts
+++ b/src/scripts/interface/apps/EditCraftingSystemDetailDialog.ts
@@ -119,7 +119,7 @@ class CraftingSystemDetailSubmissionHandler implements SubmissionHandler<Craftin
     }
 
     validate(formData: CraftingSystemDetailsJson): FormError[] {
-                const GAME = new GameProvider().globalGameObject();
+        const GAME = new GameProvider().globalGameObject();
         const errors: Array<FormError> = [];
         if (!formData.name || formData.name.length === 0) {
             errors.push({

--- a/src/scripts/interface/apps/core/Applications.ts
+++ b/src/scripts/interface/apps/core/Applications.ts
@@ -144,7 +144,7 @@ class DefaultDropHandler<V, M, S extends StateManager<V, M>> implements DropHand
         const actionData: ActionData = {
             action: targetData.get("dropTrigger"),
                 event: dropEvent,
-            data : null,
+            data : new Map<string, string>(targetData),
             document: null,
             checked: false,
             keys: {
@@ -154,16 +154,14 @@ class DefaultDropHandler<V, M, S extends StateManager<V, M>> implements DropHand
             }
         }
         if (rawJsonDropData) {
-            const data = new Map<string, string>(targetData);
             try {
                 const dropData: any = JSON.parse(rawJsonDropData);
                 Object.entries(dropData).forEach(entry => {
-                    if (data.has(entry[0])) {
+                    if (actionData.data.has(entry[0])) {
                         console.warn(`The data key "${entry[0]}" exists in both the source and target. Overwriting source value with target value. `);
                     }
-                    data.set(entry[0], <string>entry[1]);
+                    actionData.data.set(entry[0], <string>entry[1]);
                 });
-                actionData.data = data;
             } catch (e: any) {
                 console.error(`Something was dropped onto a Fabricate Drop Zone, but the event data could not be read. Caused by ${e}`);
             }
@@ -174,6 +172,9 @@ class DefaultDropHandler<V, M, S extends StateManager<V, M>> implements DropHand
                 if (Properties.module.documents.supportedTypes.indexOf(dropData.type) >= 0) {
                     const document: any = await new DefaultDocumentManager().getDocumentByUuid(dropData.uuid);
                     actionData.document = document;
+                    if (document) {
+                        actionData.data.set("partId", document.uuid);
+                    }
                 }
             } catch (e: any) {
                 console.error(`Something was dropped onto a Fabricate Drop Zone, but the event data could not be read. Caused by ${e}`);

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -9,6 +9,13 @@ import {CraftingSystemJson} from "./system/CraftingSystem";
 import {ApplicationWindow, ItemSheetExtension} from "./interface/apps/core/Applications";
 import {FabricateItemSheetTab} from "./interface/FabricateItemSheetTab";
 
+// `app` is an unknown type. Will need to consult foundry docs or crawl `foundry.js` to figure out what it is, but it seems JQuery related
+// `id` is useless to Fabricate
+Hooks.on("deleteItem", async (item: any, _app: unknown, _id: string) => {
+    console.log(`Item UUID ${item.uuid} deleted`);
+    await FabricateApplication.systemRegistry.handleItemDeleted(item.uuid);
+});
+
 Hooks.on("renderSidebarTab", async (app: any, html: any) => {
     const GAME = new GameProvider().globalGameObject();
     if (!(app instanceof ItemDirectory) || !GAME.user.isGM) {

--- a/test/PartDictionary.test.ts
+++ b/test/PartDictionary.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, expect, test} from "@jest/globals";
 import * as Sinon from "sinon";
 
-import {ErrorDecisionType, PartDictionary, PartDictionaryFactory} from "../src/scripts/system/PartDictionary";
+import {PartDictionary, PartDictionaryFactory} from "../src/scripts/system/PartDictionary";
 import {
     testComponentFive,
     testComponentFour,


### PR DESCRIPTION
## Description

Closes #74 

## Changes in the Pull Request

- Adds an async function to Fabricate System Registry `handleItemDeleted(uuid: string)` to clean up deleted items
- Adds a hook on "deleteItem" to invoke handleItemDeleted with the deleted item UUID
- Exposes this function globally on the game object

## Comments

You can invoke the `handleItemDeleted` function manually by opening the console (F12) and using the following command, and replacing the item UUID with the UUID of the item you see in error messages in the console when Fabricate tries to load a crafting system.

```
game.fabricate.SystemRegistry.handleItemDeleted("Item.tKCevfwt1D1FiuXD");
SystemRegistry.ts?1604:224 Deleted 1 Recipes, 1 components and 0 references to the Item with UUID Item.tKCevfwt1D1FiuXD.
```