### PR TITLE
docs: Essence API Examples

### DIFF
--- a/docs/api/components.md
+++ b/docs/api/components.md
@@ -457,6 +457,22 @@ const components = await game.fabricate.api.components.getAllByItemUuid(myItemUu
 
 </details>
 
+### Deleting a component by ID
+
+You can delete a component by calling `game.fabricate.api.components.deleteById()`, passing in the ID of the component to delete.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const myComponentId = "my-component-id"; // <-- Replace this with the ID of your component
+const deletedComponent = game.fabricate.api.components.deleteById(myComponentId); 
+```
+
+</details>
+
 ### Adding essences to a component
 
 You can add essences to a component by fetching it, setting the essences then calling `game.fabricate.api.components.save()`, passing in the modified component.
@@ -499,13 +515,13 @@ const componentAfterSave = await game.fabricate.api.components.save(component);
 
 </details>
 
-### Setting the salvage options for a component
+### Modifying the salvage options for a component
 
-You can add salvage options to a component by fetching it, setting the salvage option (or options) then calling `game.fabricate.api.components.save()`, passing in the modified component.
+You can add salvage options to a component by fetching it, modifying the salvage option (or options) then calling `game.fabricate.api.components.save()`, passing in the modified component.
 
 <details markdown="block">
 <summary>
-Example
+Example #1 - Adding a salvage option with catalysts
 </summary>
 
 ```typescript
@@ -524,26 +540,74 @@ const mySalvageOptionWithCatalysts = {
     }
 };
 component.setSalvageOption(mySalvageOptionWithCatalysts);
+// Save the component
+const componentAfterSave = await game.fabricate.api.components.save(component);
+```
+
+</details>
+
+<details markdown="block">
+<summary>
+Example #2 - Adding a salvage option without catalysts
+</summary>
+
+```typescript
+// Get the component
+const myComponentId = "my-component-id"; // <-- Replace this with the ID of your component
+const component = await game.fabricate.api.components.getById(myComponentId);
 
 // Create a new salvage option that doesn't require catalysts
 const mySalvageOptionWithoutCatalysts = {
-    name: "My other salvage option", // <-- Same here with naming your salvage options
-    results: { // <-- Same here with configuring the salvage results
+    name: "My other salvage option", // <-- Replace this with the name of your salvage option
+    results: { // <-- Replace the keys with the IDs of the components you want to produce when the component is salvaged and the values with the quantity to produce
         "my-salvage-id": 1
     }
 };
 component.setSalvageOption(mySalvageOptionWithoutCatalysts);
 
+// Save the component
+const componentAfterSave = await game.fabricate.api.components.save(component);
+```
+
+</details>
+
+<details markdown="block">
+<summary>
+Example #3 - Overwriting an existing salvage option
+</summary>
+
+```typescript
+// Get the component
+const myComponentId = "my-component-id"; // <-- Replace this with the ID of your component
+const component = await game.fabricate.api.components.getById(myComponentId);
+
 // You can overwrite an existing salvage option by adding the ID of the salvage option to overwrite
 // If the ID you provide doesn't match an existing salvage option, this will cause the `setSalvageOption` method to throw an error
 const mySalvageOptionToOverwrite = {
     id: "my-salvage-option-id-1", // <-- Replace this with the ID of the salvage option to overwite
-    name: "My existing salvage option to replace", // <-- Same here with naming your salvage options
-    results: { // <-- Same here with configuring the salvage results
+    name: "My existing salvage option to replace", // <-- Replace this with the name of your salvage option
+    results: { // <-- Replace the keys with the IDs of the components you want to produce when the component is salvaged and the values with the quantity to produce
         "my-salvage-id": 1
     }
+    // You can also overwrite the catalysts for an existing salvage option. Omitting them will cause them to be removed.
 };
 component.setSalvageOption(mySalvageOptionToOverwrite);
+
+// Save the component
+const componentAfterSave = await game.fabricate.api.components.save(component);
+```
+
+</details>
+
+<details markdown="block">
+<summary>
+Example #4 - Removing a salvage option
+</summary>
+
+```typescript
+// Get the component
+const myComponentId = "my-component-id"; // <-- Replace this with the ID of your component
+const component = await game.fabricate.api.components.getById(myComponentId);
 
 // You can also delete a salvage option by passing in the ID of the salvage option to delete
 component.deleteSalvageOptionById("my-salvage-option-id-2"); // <-- Replace this with the ID of the salvage option to delete
@@ -554,3 +618,28 @@ const componentAfterSave = await game.fabricate.api.components.save(component);
 
 </details>
 
+### Changing the item associated with a component
+
+You can change the item associated with a component (with a bit of a workaround) by first loading the item data using the document manager.
+Just like with other modifications, you will need to save the modified component after changing the source item data by calling `game.fabricate.api.components.save()`.
+In a later release of Fabricate, this will be simplified to allow you to simply assign the item UUID to a property on the component.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+// Get the component
+const myComponentId = "my-component-id"; // <-- Replace this with the ID of your component
+const component = await game.fabricate.api.components.getById(myComponentId);
+// Change the item data:
+//   Currently, Fabricate requires that you load the item using its document manager before assigning it to the component.
+//   This is likely to change in a future release to simplify things for API users.
+const itemUuid = "myNewItemUuid"; // <-- Replace with the UUID of the new source item
+component.itemData = await game.fabricate.api.documentManager.loadItemDataByDocumentUuid(itemUuid);
+// Save the component
+const componentAfterSave = await game.fabricate.api.components.save(component);
+```
+
+</details>

--- a/docs/api/essences.md
+++ b/docs/api/essences.md
@@ -107,17 +107,10 @@ interface EssenceAPI {
      * Creates a new essence with the given details.
      *
      * @async
-     * @param {object} options - The options to use when creating the essence
-     * @param {string} [options.name] - The name of the essence
-     * @param {string} [options.tooltip] - The tooltip text to display when the essence is hovered over
-     * @param {string} [options.iconCode] - The FontAwesome icon code for the essence icon
-     * @param {string} [options.description] - A more detailed description of the essence
-     * @param {string} [options.activeEffectSourceItemUuid] - The UUID of the item that is the source of the active
-     *   effect for this essence, if present
-     * @param {string} options.craftingSystemId - The ID of the crafting system to which this essence belongs
+     * @param {EssenceCreationOptions} essenceCreationOptions - The details of the essence to create.
      * @returns {Promise<Essence>} A Promise that resolves to the created essence.
      */
-    create({ name, tooltip, iconCode, description, activeEffectSourceItemUuid, craftingSystemId }: EssenceCreationOptions): Promise<Essence>;
+    create(essenceCreationOptions: EssenceCreationOptions): Promise<Essence>;
 
     /**
      * Saves the given essence.
@@ -236,6 +229,182 @@ interface EssenceCreationOptions {
     disabled?: boolean;
 
 }
+```
+
+</details>
+
+## Examples
+
+The examples below illustrate how to use the essence API to create, modify and delete essences.
+
+### Creating an essence
+
+Once you've created a crafting system, you can create essences for it by calling `game.fabricate.api.essences.create()` and passing in the essence details.
+To create an essence, you must provide the ID of the crafting system to which it belongs.
+In addition to the basic details for the Essence, you can optionally provide the UUID of an item to use as a source of active effects for the essence.
+Don't worry though, you can always add or remove the source item later.
+
+<details markdown="block">
+<summary>
+Example #1: Bare-bones Essence creation
+</summary>
+
+```typescript
+// Create a new essence with the default values for all properties, except the crafting system ID (we can edit them after creation)
+const myEssenceData = {
+    craftingSystemId: "myCraftingSystem" // <-- Replace with your crafting system ID
+};
+const essence = await game.fabricate.api.essences.create(myEssenceData);
+```
+
+</details>
+
+<details markdown="block">
+<summary>
+Example #2: Creating an essence without an active effect source item
+</summary>
+
+```typescript
+const craftingSystemId = "myCraftingSystem"; // <-- Replace with your crafting system ID
+const myEssenceData = {
+    name: "The Essence Display Name",
+    tooltip: "The Tooltip to display when the essence ison is hovered over",
+    // You can see the available, free icons included with Foundry VTT at https://fontawesome.com/search?m=free&o=r
+    iconCode: "fa-solid fa-mortar-pestle", // <-- This is the *full* font awesome icon code to use for the icon
+    description: "The long form detailed essence description",
+    craftingSystemId
+};
+const essence = await game.fabricate.api.essences.create(myEssenceData);
+```
+
+</details>
+
+<details markdown="block">
+<summary>
+Example #3: Creating an essence with an active effect source item
+</summary>
+
+```typescript
+const craftingSystemId = "myCraftingSystem"; // <-- Replace with your crafting system ID
+const myEssenceData = {
+    name: "The Essence Display Name",
+    tooltip: "The Tooltip to display when the essence ison is hovered over",
+    // You can see the available, free icons included with Foundry VTT at https://fontawesome.com/search?m=free&o=r
+    iconCode: "fa-solid fa-mortar-pestle", // <-- This is the *full* font awesome icon code to use for the icon
+    description: "The long form detailed essence description",
+    craftingSystemId,
+    activeEffectSourceItemUuid: "myItemUuid" // <-- Replace with the UUID of the item to use as the source of active effects for this essence
+};
+const essence = await game.fabricate.api.essences.create(myEssenceData);
+```
+
+</details>
+
+### Getting an essence by ID
+
+You can retrieve an essence by its ID by calling `game.fabricate.api.essences.getById()` and passing in the ID of the essence you want to retrieve.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const essenceId = "myEssenceId"; // <-- Replace with the ID of the essence you want to retrieve
+const essence = await game.fabricate.api.essences.getById(essenceId);
+```
+
+</details>
+
+### Getting all essences
+
+You can retrieve all essences in all crafting systems by calling `game.fabricate.api.essences.getAll()`.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const essences = await game.fabricate.api.essences.getAll();
+```
+
+</details>
+
+### Getting all essences by in a crafting system
+
+You can retrieve all essences in a crafting system by calling `game.fabricate.api.essences.getAllByCraftingSystemId()` and passing in the ID of the crafting system.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const craftingSystemId = "myCraftingSystemId"; // <-- Replace with the ID of the crafting system
+const essences = await game.fabricate.api.essences.getAllByCraftingSystemId(craftingSystemId);
+```
+
+</details>
+
+### Deleting an essence by ID
+
+You can delete an essence by its ID by calling `game.fabricate.api.essences.deleteById()` and passing in the ID of the essence you want to delete.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const essenceId = "myEssenceId"; // <-- Replace with the ID of the essence you want to delete
+const deletedEssence = await game.fabricate.api.essences.deleteById(essenceId);
+```
+
+</details>
+
+### Modifying an essence
+
+You can modify an essence by fetching and editing it, then calling `game.fabricate.api.essences.save()` and passing in the modified essence.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const essenceId = "myEssenceId"; // <-- Replace with the ID of the essence you want to modify
+const essence = await game.fabricate.api.essences.getById(essenceId);
+// Modify the essence
+essence.name = "My new essence name";
+essence.tooltip = "My new essence tooltip";
+// Save the modified essence
+await game.fabricate.api.essences.save(essence);
+```
+
+</details>
+
+### Changing the active effect source item of an essence
+
+You can change the active effect source item (with a bit of a workaround) by first loading the item data using the document manager.
+Just like with other modifications, you will need to save the modified essence after changing the active effect source by calling `game.fabricate.api.essences.save()`.
+In a later release of Fabricate, this will be simplified to allow you to simply assign the item UUID to the essence's `activeEffectSourceItemUuid` property.
+
+<details markdown="block">
+<summary>
+Example
+</summary>
+
+```typescript
+const essenceId = "myEssenceId"; // <-- Replace with the ID of the essence you want to modify
+const essence = await game.fabricate.api.essences.getById(essenceId);
+// Change the source item:
+//   Currently, Fabricate requires that you load the item using its document manager before assigning it to the essence.
+//   This is likely to change in a future release to simplify things for API users.
+const itemUuid = "myNewItemUuid"; // <-- Replace with the UUID of the new active effect source item
+essence.activeEffectSource = await game.fabricate.api.documentManager.loadItemDataByDocumentUuid(itemUuid);
+// Save the modified essence
+await game.fabricate.api.essences.save(essence);
 ```
 
 </details>

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -70,6 +70,12 @@ interface FabricateAPI {
     readonly crafting: CraftingAPI;
 
     /**
+     * Gets an instance of the Fabricate Document manager, used for loading Foundry Documents and extracting the data
+     *   they contain that is relevant to Fabricate.
+     */
+    readonly documentManager: DocumentManager;
+
+    /**
      * Suppresses notifications from Fabricate for all operations. Use {@link FabricateAPI#activateNotifications} to
      * re-enable notifications.
      */

--- a/src/scripts/api/EssenceAPI.ts
+++ b/src/scripts/api/EssenceAPI.ts
@@ -131,17 +131,10 @@ interface EssenceAPI {
      * Creates a new essence with the given details.
      *
      * @async
-     * @param {object} options - The options to use when creating the essence
-     * @param {string} [options.name] - The name of the essence
-     * @param {string} [options.tooltip] - The tooltip text to display when the essence is hovered over
-     * @param {string} [options.iconCode] - The FontAwesome icon code for the essence icon
-     * @param {string} [options.description] - A more detailed description of the essence
-     * @param {string} [options.activeEffectSourceItemUuid] - The UUID of the item that is the source of the active
-     *   effect for this essence, if present
-     * @param {string} options.craftingSystemId - The ID of the crafting system to which this essence belongs
+     * @param {EssenceCreationOptions} essenceCreationOptions - The details of the essence to create.
      * @returns {Promise<Essence>} A Promise that resolves to the created essence.
      */
-    create({ name, tooltip, iconCode, description, activeEffectSourceItemUuid, craftingSystemId }: EssenceCreationOptions): Promise<Essence>;
+    create(essenceCreationOptions: EssenceCreationOptions): Promise<Essence>;
 
     /**
      * Saves the given essence.
@@ -265,6 +258,7 @@ class DefaultEssenceAPI implements EssenceAPI {
     async create({
         name = Properties.ui.defaults.essence.name,
         tooltip = Properties.ui.defaults.essence.tooltip,
+        disabled = false,
         iconCode = Properties.ui.defaults.essence.iconCode,
         description = Properties.ui.defaults.essence.description,
         activeEffectSourceItemUuid,
@@ -272,17 +266,19 @@ class DefaultEssenceAPI implements EssenceAPI {
    }: EssenceCreationOptions): Promise<Essence> {
         const assignedIds = await this.essenceStore.listAllEntityIds();
         const id = this.identityFactory.make(assignedIds);
-        return this.essenceStore.create({
+        const essenceJson: EssenceJson = {
             id,
             name,
             tooltip,
+            disabled,
             iconCode,
             description,
-            disabled: false,
             embedded: false,
             craftingSystemId,
             activeEffectSourceItemUuid,
-        });
+        };
+        const essence = await this.essenceStore.buildEntity(essenceJson);
+        return this.save(essence);
     }
 
     async deleteById(id: string): Promise<Essence | undefined> {

--- a/src/scripts/api/FabricateAPI.ts
+++ b/src/scripts/api/FabricateAPI.ts
@@ -13,6 +13,9 @@ import Properties from "../Properties";
 import {V2Component, V2CraftingSystem, V2Essence, V2Recipe} from "../repository/migration/V2SettingsModel";
 import {NotificationService} from "../foundry/NotificationService";
 import {LocalizationService} from "../../applications/common/LocalizationService";
+import {DefaultDocumentManager, DocumentManager} from "../foundry/DocumentManager";
+import {result} from "lodash";
+import error from "svelte/types/compiler/utils/error";
 
 /**
  * Contains summary statistics about an Entity type in the Fabricate database.
@@ -142,6 +145,12 @@ interface FabricateAPI {
     readonly crafting: CraftingAPI;
 
     /**
+     * Gets an instance of the Fabricate Document manager, used for loading Foundry Documents and extracting the data
+     *   they contain that is relevant to Fabricate.
+     */
+    readonly documentManager: DocumentManager;
+
+    /**
      * Suppresses notifications from Fabricate for all operations. Use {@link FabricateAPI#activateNotifications} to
      * re-enable notifications.
      */
@@ -214,9 +223,10 @@ class DefaultFabricateAPI implements FabricateAPI {
     private readonly essenceAPI: EssenceAPI;
     private readonly craftingAPI: CraftingAPI;
     private readonly componentAPI: ComponentAPI;
+    private readonly _documentManager: DocumentManager;
+    private readonly craftingSystemAPI: CraftingSystemAPI;
     private readonly localizationService: LocalizationService;
     private readonly notificationService: NotificationService;
-    private readonly craftingSystemAPI: CraftingSystemAPI;
     private readonly settingMigrationAPI: SettingMigrationAPI;
 
     constructor({
@@ -224,6 +234,7 @@ class DefaultFabricateAPI implements FabricateAPI {
         essenceAPI,
         craftingAPI,
         componentAPI,
+        documentManager = new DefaultDocumentManager(),
         craftingSystemAPI,
         localizationService,
         notificationService,
@@ -233,6 +244,7 @@ class DefaultFabricateAPI implements FabricateAPI {
         essenceAPI: EssenceAPI;
         craftingAPI: CraftingAPI;
         componentAPI: ComponentAPI;
+        documentManager?: DocumentManager;
         craftingSystemAPI: CraftingSystemAPI;
         localizationService: LocalizationService;
         notificationService: NotificationService;
@@ -242,10 +254,15 @@ class DefaultFabricateAPI implements FabricateAPI {
         this.essenceAPI = essenceAPI;
         this.craftingAPI = craftingAPI;
         this.componentAPI = componentAPI;
+        this._documentManager = documentManager;
         this.craftingSystemAPI = craftingSystemAPI;
         this.localizationService = localizationService;
         this.notificationService = notificationService;
         this.settingMigrationAPI = settingMigrationAPI;
+    }
+
+    get documentManager(): DocumentManager {
+        return this._documentManager;
     }
 
     activateNotifications(): void {

--- a/src/scripts/crafting/component/Component.ts
+++ b/src/scripts/crafting/component/Component.ts
@@ -15,6 +15,8 @@ interface SalvageOptionConfig {
     catalysts: Record<string, number>;
 }
 
+export { SalvageOptionConfig }
+
 interface ComponentJson {
     id: string;
     embedded: boolean;

--- a/src/scripts/crafting/essence/Essence.ts
+++ b/src/scripts/crafting/essence/Essence.ts
@@ -112,7 +112,6 @@ class Essence implements Identifiable, Serializable<EssenceJson> {
         return this._activeEffectSource;
     }
 
-
     get name(): string {
         return this._name;
     }

--- a/test/FabricateAPI.test.ts
+++ b/test/FabricateAPI.test.ts
@@ -22,6 +22,7 @@ import {
 import {Combination} from "../src/scripts/common/Combination";
 import {EssenceReference} from "../src/scripts/crafting/essence/EssenceReference";
 import {ComponentReference} from "../src/scripts/crafting/component/ComponentReference";
+import {SalvageOptionConfig} from "../src/scripts/crafting/component/Component";
 
 describe("Crafting System integration", () => {
 
@@ -175,7 +176,7 @@ describe("Crafting System integration", () => {
         expect(componentOne.isSalvageable).toEqual(false);
         expect(componentOne.hasEssences).toEqual(false);
 
-        componentOne.setSalvageOption({
+        componentOne.setSalvageOption(<SalvageOptionConfig>{
             name: "salvageOptionOne",
             results: {
                 [ componentTwo.id ]: 1
@@ -189,7 +190,7 @@ describe("Crafting System integration", () => {
 
         componentOne.salvageOptions.all.find(option => option.name === "salvageOptionOne").addResult(componentTwo.id, 1);
 
-        componentOne.setSalvageOption({
+        componentOne.setSalvageOption(<SalvageOptionConfig>{
             name: "salvageOptionTwo",
             results: {
                 [ componentTwo.id ]: 1

--- a/test/stubs/StubDocumentManager.ts
+++ b/test/stubs/StubDocumentManager.ts
@@ -2,7 +2,7 @@ import {
     DocumentManager,
     FabricateItemData,
     ItemNotFoundError,
-    LoadedFabricateItemData, PendingFabricateItemData
+    LoadedFabricateItemData, NoFabricateItemData, PendingFabricateItemData
 } from "../../src/scripts/foundry/DocumentManager";
 import {Component, ComponentJson} from "../../src/scripts/crafting/component/Component";
 import {Recipe, RecipeJson} from "../../src/scripts/crafting/recipe/Recipe";
@@ -154,6 +154,9 @@ class StubDocumentManager implements DocumentManager {
     }
 
     prepareItemDataByDocumentUuid(uuid: string): FabricateItemData {
+        if (!uuid || uuid === NoFabricateItemData.UUID()) {
+            return new NoFabricateItemData();
+        }
         return new PendingFabricateItemData(uuid, () => this.loadItemDataByDocumentUuid(uuid))
     }
 

--- a/test/stubs/foundry/StubNotificationService.ts
+++ b/test/stubs/foundry/StubNotificationService.ts
@@ -1,17 +1,19 @@
+import {NotificationService} from "../../../src/scripts/foundry/NotificationService";
+
 class StubNotificationService implements NotificationService {
 
     private _suppressed: boolean;
     private _invocations: { level: string, message: string; }[] = [];
 
-    constructor(suppressed: boolean = false) {
-        this._suppressed = suppressed;
+    constructor(isSuppressed: boolean = false) {
+        this._suppressed = isSuppressed;
     }
 
-    get suppressed(): boolean {
+    get isSuppressed(): boolean {
         return this._suppressed;
     }
 
-    set suppressed(value: boolean) {
+    set isSuppressed(value: boolean) {
         this._suppressed = value;
     }
 
@@ -35,6 +37,7 @@ class StubNotificationService implements NotificationService {
         this._invocations = [];
         this._suppressed = false;
     }
+
 }
 
 export  { StubNotificationService }


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Adds Essence API examples and one component API example.

## Benefit(s)

- Enables users to make use of the essence API more easily
- Enables users to make use of the component API more easily

## Changes in this PR

- Adds essence API Examples
- Adds component item data modification example
- Splits up the component modification example into distinct examples based on the nature of the modification
- Adds the document manager to the FabricateAPI for use by API users
- Fixes the StubDocumentManager by ensuring that it recognises null or undefined item IDs as NoFabricateItemData

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

![image](https://github.com/misterpotts/fabricate/assets/17074386/8836be32-abe8-46d9-a0d4-f9d4c516c5b0)
