### PR TITLE
defect: Invisible Salvage Option

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.9.8
+title: Fabricate 0.9.9
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -12,7 +12,7 @@ has_children: true
 
 Fabricate provides a set of utility types and other classes for use in acting on essences, components and recipes.
 
-<details markdown="block">
+<details open markdown="block">
   <summary>
     Table of contents
   </summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/applications/craftingSystemManagerApp/componentManager/ComponentEditor.svelte
+++ b/src/applications/craftingSystemManagerApp/componentManager/ComponentEditor.svelte
@@ -201,7 +201,7 @@
                     <div class="fab-row">
                         <h3>{localization.localize(`${localizationPath}.component.labels.salvageHeading`)}</h3>
                     </div>
-                    {#if $selectedComponent.isSalvageable}
+                    {#if !$selectedComponent.salvageOptions.isEmpty}
                         <div class="fab-salvage-editor fab-row">
                             <Tabs bind:selectTabAtIndex={selectSalvageTab}>
                                 <TabList>

--- a/src/public/module.json
+++ b/src/public/module.json
@@ -1,7 +1,7 @@
 {
   "id": "fabricate",
   "title": "Fabricate",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "A system-agnostic, flexible crafting module for FoundryVTT",
   "authors": [
     {


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Salvage options with catalysts but no results were not displayed in the component editor. 

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

- Edit components correctly 

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- makes salvage options with only catalysts visible for components
- bumps release version to 0.9.9

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

![image](https://github.com/misterpotts/fabricate/assets/17074386/48a5f82d-301b-4aef-ad5c-c721f26072ed)
