### PR TITLE
feat: Use default item quantity path in unknown systems

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.9.10
+title: Fabricate 0.9.11
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/docs/api/crafting.md
+++ b/docs/api/crafting.md
@@ -268,9 +268,11 @@ The examples below illustrate how to use the crafting API to craft recipes and s
 
 ### Setting the game system item quantity property path
 
-Fabricate treats items in unknown game systems as having a quantity of 1.
-You'll need to configure this property if your game system of choice supports item quantities and is not known to Fabricate.
-You can do this by making Fabricate aware of the item quantity property path for your game system.
+By default, Fabricate looks for item quantity information at the path `system.quantity` in an item's data.
+If no value is found at this path, or the path is not valid, Fabricate treats all items in your game world as **having a quantity of 1**.
+
+You'll need to configure this property if your game system of choice supports item quantities and the item data path is not known to Fabricate.
+You can do this by making Fabricate aware of the item quantity property path for your world's game system.
 It's really easy to do this, just call `CraftingAPI#setGameSystemItemQuantityPropertyPath`, passing in the game system ID and the property path to use.
 
 <details markdown="block">

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -411,6 +411,9 @@ Fabricate knows how to read and write item quantities for the following game sys
 
 - D&D 5th Edition
 - Pathfinder 2nd Edition
+- Any other game system that uses `system.quantity` in item document data
 
-Fabricate needs to be told where to find item quantity information for your world's game system.
+By default, Fabricate looks for item quantity information at the path `system.quantity` in an item's data.
+If no value is found at this path, or the path is not valid, Fabricate treats all items in your game world as **having a quantity of 1**.
+If your world's game system uses a different path, you can tell Fabricate where to find it by changing the `game.fabricate.api.crafting.itemQuantityPropertyPath` setting.
 See the [example in the Crafting API documentation](/fabricate/api/crafting#setting-the-game-system-item-quantity-property-path) for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/scripts/Properties.ts
+++ b/src/scripts/Properties.ts
@@ -78,6 +78,7 @@ const Properties = {
             key: "modelVersion",
             targetValue: SettingVersion.V3
         },
+        defaultItemQuantityPropertyPath: "system.quantity"
     }
 };
 

--- a/src/scripts/actor/InventoryFactory.ts
+++ b/src/scripts/actor/InventoryFactory.ts
@@ -1,7 +1,11 @@
 import {CraftingInventory, Inventory} from "./Inventory";
 import {DefaultObjectUtility, ObjectUtility} from "../foundry/ObjectUtility";
 import {Component} from "../crafting/component/Component";
-import {ItemDataManager, PropertyPathAwareItemDataManager, SingletonItemDataManager} from "./ItemDataManager";
+import {
+    ItemDataManager,
+    OptimisticItemDataManagerFactory,
+    PropertyPathAwareItemDataManager
+} from "./ItemDataManager";
 import {LocalizationService} from "../../applications/common/LocalizationService";
 
 interface InventoryFactory {
@@ -25,18 +29,22 @@ class DefaultInventoryFactory implements InventoryFactory {
     private readonly _localizationService: LocalizationService;
     private readonly _objectUtility: ObjectUtility;
     private readonly _gameSystemItemQuantityPropertyPaths: Map<string, string>;
+    private readonly _optimisticItemDataManagerFactory: OptimisticItemDataManagerFactory;
 
     constructor({
-        localizationService,
         objectUtility = new DefaultObjectUtility(),
+        localizationService,
         gameSystemItemQuantityPropertyPaths = DefaultInventoryFactory._KNOWN_GAME_SYSTEM_ITEM_QUANTITY_PROPERTY_PATHS,
+        optimisticItemDataManagerFactory = new OptimisticItemDataManagerFactory({ objectUtils: objectUtility }),
     }: {
-        localizationService: LocalizationService;
         objectUtility?: ObjectUtility;
+        localizationService: LocalizationService;
         gameSystemItemQuantityPropertyPaths?: Map<string, string>;
+        optimisticItemDataManagerFactory?: OptimisticItemDataManagerFactory;
     }) {
-        this._localizationService = localizationService;
         this._objectUtility = objectUtility;
+        this._localizationService = localizationService;
+        this._optimisticItemDataManagerFactory = optimisticItemDataManagerFactory;
         this._gameSystemItemQuantityPropertyPaths = gameSystemItemQuantityPropertyPaths;
     }
 
@@ -57,7 +65,7 @@ class DefaultInventoryFactory implements InventoryFactory {
                 propertyPath: this._gameSystemItemQuantityPropertyPaths.get(gameSystemId),
             });
         } else {
-            itemDataManager = new SingletonItemDataManager({ objectUtils: this._objectUtility } );
+            itemDataManager = this._optimisticItemDataManagerFactory.make();
         }
 
         return new CraftingInventory({

--- a/test/CraftingAPI.test.ts
+++ b/test/CraftingAPI.test.ts
@@ -13,7 +13,6 @@ import {allTestRecipes} from "./test_data/TestRecipes";
 import {allTestComponents, testComponentFour, testComponentThree} from "./test_data/TestCraftingComponents";
 import {allTestEssences} from "./test_data/TestEssences";
 import {testCraftingSystemOne} from "./test_data/TestCrafingSystem";
-import {BaseActor} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs";
 import {StubActorFactory} from "./stubs/StubActorFactory";
 import {DefaultCombination} from "../src/scripts/common/Combination";
 import {
@@ -27,7 +26,9 @@ describe("Crafting API", () => {
 
         test("should salvage a component with one salvage option", async () => {
 
-            const stubActor = new StubActorFactory().make(DefaultCombination.of(testComponentFour));
+            const stubActor = new StubActorFactory().make({
+                ownedComponents: DefaultCombination.of(testComponentFour)
+            });
 
             const underTest = make(new Map([ [stubActor.id, stubActor] ]));
             const result = await underTest.salvageComponent({
@@ -76,7 +77,7 @@ describe("Crafting API", () => {
 
 });
 
-function make(stubActors: Map<string, BaseActor> = new Map()): CraftingAPI {
+function make(stubActors: Map<string, Actor> = new Map()): CraftingAPI {
     const stubLocalizationService = new StubLocalizationService();
     return new DefaultCraftingAPI({
         recipeAPI: new StubRecipeAPI({

--- a/test/CraftingInventory.test.ts
+++ b/test/CraftingInventory.test.ts
@@ -10,7 +10,7 @@ import {
     testComponentThree,
     testComponentTwo
 } from "./test_data/TestCraftingComponents";
-import {DefaultUnit, Unit} from "../src/scripts/common/Unit";
+import {DefaultUnit} from "../src/scripts/common/Unit";
 import {SimpleInventoryAction} from "../src/scripts/actor/InventoryAction";
 import {DefaultCombination} from "../src/scripts/common/Combination";
 
@@ -46,12 +46,12 @@ describe("Crafting Inventory", () => {
         test("should index actor's inventory with some fabricate items", () => {
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
             const underTest = dnd5eInventoryFactory.make("dnd5e", stubActor, getAllTestComponents());
             const contents = underTest.getContents();
             expect(contents).not.toBeNull();
@@ -61,15 +61,33 @@ describe("Crafting Inventory", () => {
 
         });
 
-        test("should index actor's inventory without counting item quantity if no item quantity property path is known", () => {
+        test("should index actor's inventory in unknown system if default item quantity property path is populated on items", () => {
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
+            const underTest = dnd5eInventoryFactory.make("notDnd5e", stubActor, getAllTestComponents());
+            const contents = underTest.getContents();
+            expect(contents).not.toBeNull();
+            expect(contents.size).toBe(5);
+            expect(contents.amountFor(testComponentTwo)).toBe(3);
+            expect(contents.amountFor(testComponentFive)).toBe(2);
+
+        });
+
+        test("should index actor's inventory without counting item quantity if no item quantity property path is known and default item quantity path is not populated on items", () => {
+
+            const stubActor = new StubActorFactory("data.amount")
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
+                        new DefaultUnit(testComponentTwo, 3),
+                        new DefaultUnit(testComponentFive, 2),
+                    ])
+                });
             const underTest = dnd5eInventoryFactory.make("notDnd5e", stubActor, getAllTestComponents());
             const contents = underTest.getContents();
             expect(contents).not.toBeNull();
@@ -89,12 +107,12 @@ describe("Crafting Inventory", () => {
             inventoryFactory.registerGameSystemItemQuantityPropertyPath("notDnd5e", "system.quantity");
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
             const underTest = inventoryFactory.make("dnd5e", stubActor, getAllTestComponents());
             const contents = underTest.getContents();
             expect(contents).not.toBeNull();
@@ -111,12 +129,12 @@ describe("Crafting Inventory", () => {
         test("should add items without removing if no removals are specified", async () => {
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
             const underTest = dnd5eInventoryFactory.make("dnd5e", stubActor, getAllTestComponents());
             const addOneTestComponentThreeOnly = new SimpleInventoryAction({
                 additions: DefaultCombination.ofUnits([new DefaultUnit(testComponentThree, 1)])
@@ -134,12 +152,12 @@ describe("Crafting Inventory", () => {
         test("should remove items without adding if no additions are specified", async () => {
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
             const underTest = dnd5eInventoryFactory.make("dnd5e", stubActor, getAllTestComponents());
             const removeTwoTestComponentTwoOnly = new SimpleInventoryAction({
                 removals: DefaultCombination.ofUnits([new DefaultUnit(testComponentTwo, 2)])
@@ -156,12 +174,12 @@ describe("Crafting Inventory", () => {
         test("should add and remove items if both are specified", async () => {
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
             const underTest = dnd5eInventoryFactory.make("dnd5e", stubActor, getAllTestComponents());
             const removeTwoTestComponentTwoAndTestComponentFiveAndAddTwoTestComponentThree = new SimpleInventoryAction({
                 removals: DefaultCombination.ofUnits([
@@ -184,12 +202,12 @@ describe("Crafting Inventory", () => {
         test("should rationalise complete overlapping additions and removals to no action", async () => {
 
             const stubActor = new StubActorFactory()
-                .make(
-                    DefaultCombination.ofUnits([
+                .make({
+                    ownedComponents: DefaultCombination.ofUnits([
                         new DefaultUnit(testComponentTwo, 3),
                         new DefaultUnit(testComponentFive, 2),
                     ])
-                );
+                });
             const underTest = dnd5eInventoryFactory.make("dnd5e", stubActor, getAllTestComponents());
             const removeTwoTestComponentTFourAndAddTwoTestComponentFour = new SimpleInventoryAction({
                 removals: DefaultCombination.ofUnits([new DefaultUnit(testComponentFour, 2)]),

--- a/test/stubs/StubActorFactory.ts
+++ b/test/stubs/StubActorFactory.ts
@@ -1,15 +1,27 @@
 import {StubItem} from "./StubItem";
-import {BaseActor} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs";
 import {Combination, DefaultCombination} from "../../src/scripts/common/Combination";
 import {Component} from "../../src/scripts/crafting/component/Component";
+import {ObjectUtility} from "../../src/scripts/foundry/ObjectUtility";
+import {StubObjectUtility} from "./StubObjectUtility";
 
 class StubActorFactory {
 
-    constructor() {}
+    private readonly objectUtility: ObjectUtility = new StubObjectUtility(false);
+    private readonly itemQuantityPropertyPath: string;
 
-    public make(ownedComponents: Combination<Component> = DefaultCombination.EMPTY(), additionalItemCount = 10): BaseActor {
+    constructor(itemQuantityPropertyPath = "system.quantity") {
+        this.itemQuantityPropertyPath = itemQuantityPropertyPath;
+    }
+
+    public make({
+        ownedComponents = DefaultCombination.EMPTY(),
+        additionalItemCount = 10
+    }: {
+        ownedComponents?: Combination<Component>;
+        additionalItemCount?: number;
+    } = {}): Actor {
         const items = this.generateInventory(ownedComponents, additionalItemCount);
-        return <BaseActor><unknown>{
+        return <Actor><unknown>{
             id: randomIdentifier(),
             name: "Stub Actor",
             items,
@@ -71,17 +83,16 @@ class StubActorFactory {
         }
         ownedComponents.units.map(unit => {
             const id = randomIdentifier();
-            result.set(id, new StubItem({
+            const stubItemData = {
                 id: id,
                 flags: {
                     core: {
                         sourceId: unit.element.itemUuid
                     }
-                },
-                system: {
-                    quantity: unit.quantity
                 }
-            }));
+            };
+            this.objectUtility.setPropertyValue(this.itemQuantityPropertyPath,stubItemData, unit.quantity);
+            result.set(id, new StubItem(stubItemData));
         });
         return result;
     }

--- a/test/stubs/StubObjectUtility.ts
+++ b/test/stubs/StubObjectUtility.ts
@@ -3,6 +3,16 @@ import * as _ from "lodash";
 
 class StubObjectUtility implements ObjectUtility {
 
+    private readonly strict: boolean;
+
+    constructor(isStrict = false) {
+        this.strict = isStrict;
+    }
+
+    get isStrict(): boolean {
+        return this.strict;
+    }
+
     duplicate<T extends {}>(source: T): T {
         return _.cloneDeep(source);
     }
@@ -12,14 +22,16 @@ class StubObjectUtility implements ObjectUtility {
     }
 
     getPropertyValue<T>(propertyPath: string, object: object): T {
-        if (!_.has(object, propertyPath)) {
+        const pathExists = _.has(object, propertyPath);
+        if (!pathExists && this.strict) {
             throw new Error(`Property path ${propertyPath} not found on object`);
         }
-        return _.get(object, propertyPath);
+        return _.get(object, propertyPath, undefined);
     }
 
     setPropertyValue<T>(propertyPath: string, object: object, value: T): void {
-        if (!_.has(object, propertyPath)) {
+        const pathExists = _.has(object, propertyPath);
+        if (!pathExists && this.strict) {
             throw new Error(`Property path ${propertyPath} not found on object`);
         }
         _.set(object, propertyPath, value);

--- a/test/stubs/foundry/StubGameProvider.ts
+++ b/test/stubs/foundry/StubGameProvider.ts
@@ -1,5 +1,4 @@
 import {GameProvider} from "../../../src/scripts/foundry/GameProvider";
-import {BaseActor} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/documents.mjs";
 
 class StubGameObject {
 
@@ -18,7 +17,7 @@ class StubGameProvider implements GameProvider {
 
     private readonly gameSystemId: string;
     private readonly stubGameObject: StubGameObject;
-    private readonly stubActors: Map<string, BaseActor>;
+    private readonly stubActors: Map<string, Actor>;
 
     constructor({
         gameSystemId = "dnd5e",
@@ -27,7 +26,7 @@ class StubGameProvider implements GameProvider {
     }: {
         gameSystemId?: string,
         stubGameObject?: StubGameObject;
-        stubActors?: Map<string, BaseActor>,
+        stubActors?: Map<string, Actor>,
     } = {}) {
         this.gameSystemId = gameSystemId;
         this.stubGameObject = stubGameObject;
@@ -42,7 +41,7 @@ class StubGameProvider implements GameProvider {
         return this.gameSystemId;
     }
 
-    async loadActor(actorId: string): Promise<BaseActor> {
+    async loadActor(actorId: string): Promise<Actor> {
         return this.stubActors.get(actorId);
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Fabricate now uses the default path `system.quantity` for all item quantity data. If not found, it falls back to treating items as having a quantity of 1. 

Before, if your game system `myCustomGameSystem` uses the item data path `system.quantity` you would still need to manually configure Fabricate to make it aware of that game system. Now, you don't have to do anything, unless your game system uses a different path, say `system.amount`. In that case, you'll still need to configure Fabricate so that it is aware of your game system's item data quantities. 

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

- Works with more game systems without users having to set-up Fabricate!

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- Adds OptimisticItemDataManager, which uses the PropertyPathAwareItemDataManager and the SingletonItemDataManager
- Sets the default item data quantity path to `system.quantity`
- Updates the documentation to reflect this
- Updates the test suite to reflect the new behaviour

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

N/A