### PR TITLE
docs: clarify the property path setting for item quantity

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -415,5 +415,5 @@ Fabricate knows how to read and write item quantities for the following game sys
 
 By default, Fabricate looks for item quantity information at the path `system.quantity` in an item's data.
 If no value is found at this path, or the path is not valid, Fabricate treats all items in your game world as **having a quantity of 1**.
-If your world's game system uses a different path, you can tell Fabricate where to find it by changing the `game.fabricate.api.crafting.itemQuantityPropertyPath` setting.
+If your world's game system uses a different path, you can tell Fabricate where to find it by changing the `itemQuantityPropertyPath` setting in the Crafting API.
 See the [example in the Crafting API documentation](/fabricate/api/crafting#setting-the-game-system-item-quantity-property-path) for details.


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

he existing docs make it seem like this is a property that can be directly set.

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

- reduce confusion about property path setting

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- clarifies language
- removes property path (it's not real)

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

![image](https://github.com/misterpotts/fabricate/assets/17074386/645c30b8-68f0-4684-90a1-fa5ce474b3e6)
