### PR TITLE
Feat: Render new actor crafting app

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.10.1
+title: Fabricate 0.10.2
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/applications/actorCraftingApp/ActorCraftingApp.svelte
+++ b/src/applications/actorCraftingApp/ActorCraftingApp.svelte
@@ -1,0 +1,8 @@
+<!-- ActorCraftingApp.svelte -->
+<script lang="ts">
+
+</script>
+
+<div>
+    <p>Hello from the actor crafting app!</p>
+</div>

--- a/src/applications/actorCraftingApp/ActorCraftingAppFactory.ts
+++ b/src/applications/actorCraftingApp/ActorCraftingAppFactory.ts
@@ -1,0 +1,80 @@
+import {SvelteApplication} from "../SvelteApplication";
+import {ActorCraftingAppViewType} from "./ActorCraftingAppViewType";
+import {LocalizationService} from "../common/LocalizationService";
+import {FabricateAPI} from "../../scripts/api/FabricateAPI";
+import Properties from "../../scripts/Properties";
+import ActorCraftingApp from "./ActorCraftingApp.svelte";
+interface MakeOptions {
+
+    view?: ActorCraftingAppViewType;
+    sourceActorId: string;
+    targetActorId: string;
+    selectedRecipeId?: string;
+    selectedComponentId?: string;
+
+}
+
+interface ActorCraftingAppFactory {
+
+    make(options: MakeOptions): Promise<SvelteApplication>;
+
+}
+
+export { ActorCraftingAppFactory }
+
+class DefaultActorCraftingAppFactory implements ActorCraftingAppFactory {
+
+    private static readonly DEFAULT_VIEW: ActorCraftingAppViewType = ActorCraftingAppViewType.BROWSE_COMPONENTS;
+
+    private readonly localizationService: LocalizationService;
+    private readonly fabricateAPI: FabricateAPI;
+
+    constructor({
+        fabricateAPI,
+        localizationService,
+    }: {
+        fabricateAPI: FabricateAPI;
+        localizationService: LocalizationService;
+    }) {
+        this.fabricateAPI = fabricateAPI;
+        this.localizationService = localizationService;
+    }
+
+    async make({
+        view = DefaultActorCraftingAppFactory.DEFAULT_VIEW,
+        sourceActorId,
+        targetActorId,
+        selectedRecipeId,
+        selectedComponentId,
+     }: MakeOptions): Promise<SvelteApplication> {
+
+        const applicationOptions = {
+            title: this.localizationService.localize(`${Properties.module.id}.ActorCraftingApp.title`),
+            id: Properties.ui.apps.actorCraftingApp.id,
+            resizable: true,
+            width: 1020,
+            height: 780
+        }
+
+        return new SvelteApplication({
+            applicationOptions,
+            svelteConfig: {
+                options: {
+                    props: {
+                        localization: this.localizationService,
+                        fabricateAPI: this.fabricateAPI,
+                        view,
+                        sourceActorId,
+                        targetActorId,
+                        selectedRecipeId,
+                        selectedComponentId,
+                    }
+                },
+                componentType: ActorCraftingApp
+            }
+        });
+    }
+
+}
+
+export { DefaultActorCraftingAppFactory }

--- a/src/applications/actorCraftingApp/ActorCraftingAppViewType.ts
+++ b/src/applications/actorCraftingApp/ActorCraftingAppViewType.ts
@@ -1,0 +1,10 @@
+enum ActorCraftingAppViewType {
+
+    CRAFTING = "crafting",
+    SALVAGING = "salvaging",
+    BROWSE_RECIPES = "browse-recipes",
+    BROWSE_COMPONENTS = "browse-components",
+
+}
+
+export { ActorCraftingAppViewType };

--- a/src/public/lang/en.json
+++ b/src/public/lang/en.json
@@ -192,6 +192,9 @@
         "unrecognisedComponent": "The Crafting Component {componentName} is not a part of this crafting system. "
       }
     },
+    "ActorCraftingApp": {
+      "title": "Fabricate | Crafting"
+    },
     "ComponentSalvageApp": {
       "title": "Fabricate | Component Salvage | {actorName}",
       "header": {

--- a/src/scripts/Properties.ts
+++ b/src/scripts/Properties.ts
@@ -50,6 +50,9 @@ const Properties = {
         apps: {
             craftingSystemManager: {
                 id: "fabricate-crafting-system-manager"
+            },
+            actorCraftingApp: {
+                id: "fabricate-actor-crafting-app"
             }
         }
     },

--- a/src/scripts/api/FabricateUserInterfaceAPI.ts
+++ b/src/scripts/api/FabricateUserInterfaceAPI.ts
@@ -3,6 +3,7 @@ import {ComponentSalvageAppCatalog} from "../../applications/componentSalvageApp
 import {RecipeCraftingAppCatalog} from "../../applications/recipeCraftingApp/RecipeCraftingAppCatalog";
 import {FabricateAPI} from "./FabricateAPI";
 import {GameProvider} from "../foundry/GameProvider";
+import {FabricatePatreonAPI} from "../patreon/FabricatePatreonAPI";
 
 /**
  * Represents an API for managing the Fabricate user interface.
@@ -34,6 +35,8 @@ interface FabricateUserInterfaceAPI {
      */
     renderRecipeCraftingApp(actorId: string, recipeId: string): Promise<void>;
 
+    renderActorCraftingApp(args: { targetActorId?: string; sourceActorId?: string; selectedRecipeId?: string; selectedSalvageId?: string; }): Promise<void>;
+
 }
 
 export { FabricateUserInterfaceAPI };
@@ -42,6 +45,7 @@ class DefaultFabricateUserInterfaceAPI implements FabricateUserInterfaceAPI {
 
     private readonly fabricateAPI: FabricateAPI;
     private readonly gameProvider: GameProvider;
+    private readonly fabricatePatreonAPI: FabricatePatreonAPI;
     private readonly recipeCraftingAppCatalog: RecipeCraftingAppCatalog;
     private readonly componentSalvageAppCatalog: ComponentSalvageAppCatalog;
     private readonly craftingSystemManagerAppFactory: CraftingSystemManagerAppFactory
@@ -49,18 +53,21 @@ class DefaultFabricateUserInterfaceAPI implements FabricateUserInterfaceAPI {
     constructor({
         fabricateAPI,
         gameProvider,
+        fabricatePatreonAPI,
         recipeCraftingAppCatalog,
         componentSalvageAppCatalog,
         craftingSystemManagerAppFactory,
     }: {
         fabricateAPI: FabricateAPI;
         gameProvider: GameProvider;
+        fabricatePatreonAPI: FabricatePatreonAPI;
         recipeCraftingAppCatalog: RecipeCraftingAppCatalog;
         componentSalvageAppCatalog: ComponentSalvageAppCatalog;
         craftingSystemManagerAppFactory: CraftingSystemManagerAppFactory;
     }) {
         this.fabricateAPI = fabricateAPI;
         this.gameProvider = gameProvider;
+        this.fabricatePatreonAPI = fabricatePatreonAPI;
         this.recipeCraftingAppCatalog = recipeCraftingAppCatalog;
         this.componentSalvageAppCatalog = componentSalvageAppCatalog;
         this.craftingSystemManagerAppFactory = craftingSystemManagerAppFactory;
@@ -85,6 +92,23 @@ class DefaultFabricateUserInterfaceAPI implements FabricateUserInterfaceAPI {
         await recipe.load();
         const application = await this.recipeCraftingAppCatalog.load(recipe, actor);
         application.render(true);
+    }
+
+    async renderActorCraftingApp({
+        targetActorId,
+        sourceActorId,
+        selectedRecipeId,
+        selectedSalvageId,
+    }: {
+        targetActorId?: string;
+        sourceActorId?: string;
+        selectedRecipeId?: string;
+        selectedSalvageId?: string;
+    }): Promise<void> {
+        if (!this.fabricatePatreonAPI.isEnabled("new-ui")) {
+            return;
+        }
+        console.log("renderActorCraftingApp", { targetActorId, sourceActorId, selectedRecipeId, selectedSalvageId });
     }
 
 }

--- a/src/scripts/api/FabricateUserInterfaceAPIFactory.ts
+++ b/src/scripts/api/FabricateUserInterfaceAPIFactory.ts
@@ -8,6 +8,7 @@ import {FabricateAPI} from "./FabricateAPI";
 import {DefaultLocalizationService} from "../../applications/common/LocalizationService";
 import {DefaultGameProvider, GameProvider} from "../foundry/GameProvider";
 import {FabricatePatreonAPI} from "../patreon/FabricatePatreonAPI";
+import {DefaultActorCraftingAppFactory} from "../../applications/actorCraftingApp/ActorCraftingAppFactory";
 
 interface FabricateUserInterfaceAPIFactory {
 
@@ -45,6 +46,11 @@ class DefaultFabricateUserInterfaceAPIFactory implements FabricateUserInterfaceA
             localizationService
         });
 
+        const actorCraftingAppFactory = new DefaultActorCraftingAppFactory({
+            fabricateAPI: this.fabricateAPI,
+            localizationService
+        });
+
         const componentSalvageAppCatalog = new DefaultComponentSalvageAppCatalog({
             componentSalvageAppFactory: new DefaultComponentSalvageAppFactory({
                 localizationService,
@@ -62,9 +68,10 @@ class DefaultFabricateUserInterfaceAPIFactory implements FabricateUserInterfaceA
         });
 
         return new DefaultFabricateUserInterfaceAPI({
-            craftingSystemManagerAppFactory,
-            componentSalvageAppCatalog,
+            actorCraftingAppFactory,
             recipeCraftingAppCatalog,
+            componentSalvageAppCatalog,
+            craftingSystemManagerAppFactory,
             fabricateAPI: this.fabricateAPI,
             gameProvider: this.gameProvider,
             fabricatePatreonAPI: this.fabricatePatreonAPI,

--- a/src/scripts/api/FabricateUserInterfaceAPIFactory.ts
+++ b/src/scripts/api/FabricateUserInterfaceAPIFactory.ts
@@ -7,6 +7,7 @@ import {DefaultRecipeCraftingAppFactory} from "../../applications/recipeCrafting
 import {FabricateAPI} from "./FabricateAPI";
 import {DefaultLocalizationService} from "../../applications/common/LocalizationService";
 import {DefaultGameProvider, GameProvider} from "../foundry/GameProvider";
+import {FabricatePatreonAPI} from "../patreon/FabricatePatreonAPI";
 
 interface FabricateUserInterfaceAPIFactory {
 
@@ -19,16 +20,20 @@ class DefaultFabricateUserInterfaceAPIFactory implements FabricateUserInterfaceA
 
     private readonly fabricateAPI: FabricateAPI;
     private readonly gameProvider: GameProvider;
+    private readonly fabricatePatreonAPI: FabricatePatreonAPI;
 
     constructor({
         fabricateAPI,
         gameProvider = new DefaultGameProvider(),
+        fabricatePatreonAPI
     }: {
         fabricateAPI: FabricateAPI;
         gameProvider?: GameProvider;
+        fabricatePatreonAPI: FabricatePatreonAPI;
     }) {
         this.fabricateAPI = fabricateAPI;
         this.gameProvider = gameProvider;
+        this.fabricatePatreonAPI = fabricatePatreonAPI;
     }
 
     make(): FabricateUserInterfaceAPI {
@@ -62,6 +67,7 @@ class DefaultFabricateUserInterfaceAPIFactory implements FabricateUserInterfaceA
             recipeCraftingAppCatalog,
             fabricateAPI: this.fabricateAPI,
             gameProvider: this.gameProvider,
+            fabricatePatreonAPI: this.fabricatePatreonAPI,
         });
     }
 

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -65,7 +65,7 @@ Hooks.once('ready', async () => {
             id: "new-ui",
             name: "New UI",
             description: "Fabricate's new user interface, including the Actor sheet crafting application.",
-            targets: [ "7916c71e8ebaf1eaa2fd5a22cae69ea26cef0eeb473fafe731d4285455832f14" ]
+            targets: [ "88a8dcd4bf1ff9207228bcbf47e8f2a2606847cc4cf83d9e5d9016a4f7c251f0" ]
         }),
     ]);
 

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -57,13 +57,6 @@ Hooks.once('ready', async () => {
 
     fabricateAPI = fabricateAPIFactory.make();
 
-    const fabricateUserInterfaceAPIFactory = new DefaultFabricateUserInterfaceAPIFactory({
-        fabricateAPI,
-        gameProvider,
-    });
-
-    fabricateUserInterfaceAPI = fabricateUserInterfaceAPIFactory.make();
-
     const patreonAPIFactory = new DefaultFabricatePatreonAPIFactory({
         clientSettings: gameObject.settings,
     });
@@ -75,6 +68,14 @@ Hooks.once('ready', async () => {
             targets: [ "7916c71e8ebaf1eaa2fd5a22cae69ea26cef0eeb473fafe731d4285455832f14" ]
         }),
     ]);
+
+    const fabricateUserInterfaceAPIFactory = new DefaultFabricateUserInterfaceAPIFactory({
+        fabricateAPI,
+        gameProvider,
+        fabricatePatreonAPI,
+    });
+
+    fabricateUserInterfaceAPI = fabricateUserInterfaceAPIFactory.make();
 
     // Sets the default value of game.fabricate to an empty object
     // @ts-ignore
@@ -136,7 +137,9 @@ Hooks.on("renderActorSheet", async (actorSheet: ActorSheet, html: any) => {
         class: "fab-actor-sheet-header-button",
         icon: "fa-solid fa-screwdriver-wrench",
         onclick: async () => {
-            console.log("Fabricate | Crafting button clicked")
+            await fabricateUserInterfaceAPI.renderActorCraftingApp({
+                targetActorId: actorSheet.actor.id
+            });
         }
     };
     const button = $(`<a class="${headerButton.class}" data-tooltip="${headerButton.tooltip}"><i class="${headerButton.icon}"></i>${headerButton.label}</a>`);
@@ -209,7 +212,7 @@ Hooks.on("renderItemSheet", async (itemSheet: ItemSheet, html: any) => {
     let title = header.children(".window-title");
     additionalHeaderButtons.forEach(headerButton => {
         const button = $(`<a class="${headerButton.class}" data-tooltip="${headerButton.tooltip}"><i class="${headerButton.icon}"></i>${headerButton.label}</a>`);
-        button.click(() => headerButton.onclick());
+        button.on("click", () => headerButton.onclick());
         button.insertAfter(title);
     });
 });

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -143,7 +143,7 @@ Hooks.on("renderActorSheet", async (actorSheet: ActorSheet, html: any) => {
         }
     };
     const button = $(`<a class="${headerButton.class}" data-tooltip="${headerButton.tooltip}"><i class="${headerButton.icon}"></i>${headerButton.label}</a>`);
-    button.on("click", () => headerButton.onclick());
+    button.on("click", headerButton.onclick);
     button.insertAfter(title);
 
 });

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -136,6 +136,12 @@ declare interface Game {
 
     i18n: FoundryI18NLocalization;
 
+    fabricate: {
+        patreon: any;
+        api: any;
+        ui: any;
+    }
+
 }
 
 declare const game: Game;
@@ -408,6 +414,18 @@ declare interface ItemSheet {
     document: Document;
 
     actor?: Actor;
+
+}
+
+declare interface ActorSheet {
+
+    actor: Actor;
+
+    document: Document;
+
+    rendered: boolean;
+
+    position: { width: number; height: number; top: number; left: number; scale: number; zIndex: number };
 
 }
 


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Renders a button on the Actor sheet that, when clicked, opens an empty Crafting app. This will be the foundation of the new UI!

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

- Iteration towards the new UI
- Proves out the new "Patron Secret Key" feature

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- Adds a button to the actor sheet header to open an empty crafting app
- Releases `0.10.2`

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

![image](https://github.com/misterpotts/fabricate/assets/17074386/18a1cbb0-c270-45a4-a6fc-7416022e6b86)
