### PR TITLE
Defect: Option name can't be set

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.10.15
+title: Fabricate 0.10.16
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/scripts/common/Options.ts
+++ b/src/scripts/common/Options.ts
@@ -65,7 +65,7 @@ export {Option}
 class DefaultOption<T> implements Option<T> {
 
     private readonly _id: string;
-    private readonly _name: string;
+    private _name: string;
     private readonly _value: T;
 
     constructor({
@@ -92,6 +92,10 @@ class DefaultOption<T> implements Option<T> {
 
     get value(): T {
         return this._value;
+    }
+
+    set name(name: string) {
+        this._name = name;
     }
 
     clone(id: string): Option<T> {
@@ -152,6 +156,10 @@ class DefaultSerializableOption<J, T extends Serializable<J>> implements Seriali
 
     get value(): T {
         return this._option.value;
+    }
+
+    set name(name: string) {
+        this._option.name = name;
     }
 
     public toJson(): OptionJson<J> {


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Salvage and crafting option names are currently not able to be changed from the default value.

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

Enables GMs to set meaningful names for their recipe and salvage options again.

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- Makes the DefaultOption name mutable

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

![image](https://github.com/misterpotts/fabricate/assets/17074386/742ea7bc-8c63-43c6-9bd8-7f34ed3ab611)
