### PR TITLE
Fix: Item avatar rendering fix

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.10.21
+title: Fabricate 0.10.22
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/applications/actorCraftingApp/ComponentSalvageProcess.svelte
+++ b/src/applications/actorCraftingApp/ComponentSalvageProcess.svelte
@@ -174,6 +174,7 @@
                                     <ItemCard quantity={productUnit.quantity}
                                               name={loadedComponent.name}
                                               imageUrl={loadedComponent.imageUrl}
+                                              imageWidth="w-[104px]"
                                               essences={dereferenceEssences(loadedComponent)}/>
                                 {/await}
                             {/each}
@@ -192,7 +193,8 @@
                                     <ItemCard quantity={catalystUnit.actual.quantity}
                                               requiredQuantity={catalystUnit.target.quantity}
                                               name={loadedComponent.name}
-                                              imageUrl={loadedComponent.imageUrl}/>
+                                              imageUrl={loadedComponent.imageUrl}
+                                              imageWidth="w-[104px]" />
                                 {/await}
                             {/each}
                         </div>
@@ -212,6 +214,7 @@
                                 <ItemCard quantity={productUnit.quantity}
                                           name={loadedComponent.name}
                                           imageUrl={loadedComponent.imageUrl}
+                                          imageWidth="w-[104px]"
                                           essences={dereferenceEssences(loadedComponent)}/>
                             {/await}
                         {/each}

--- a/src/applications/actorCraftingApp/ItemCard.svelte
+++ b/src/applications/actorCraftingApp/ItemCard.svelte
@@ -36,11 +36,11 @@
             rounded={imageRounding}/>
     {#if typeof requiredQuantity !== "undefined"}
         {#if quantity >= requiredQuantity}
-            <span class="absolute bottom-0 left-0 rounded-bl-lg w-24 bg-success-500 text-center text-black font-bold h-5 leading-5">
+            <span class="absolute bottom-0 left-0 rounded-bl-lg {imageWidth} bg-success-500 text-center text-black font-bold h-5 leading-5">
                 {quantity} / {requiredQuantity}
             </span>
         {:else}
-            <span class="absolute bottom-0 left-0 rounded-bl-lg w-24 bg-error-500 text-center text-black font-bold h-5 leading-5">
+            <span class="absolute bottom-0 left-0 rounded-bl-lg {imageWidth} bg-error-500 text-center text-black font-bold h-5 leading-5">
                 {quantity} / {requiredQuantity}
             </span>
         {/if}

--- a/test/stubs/api/StubRecipeAPI.ts
+++ b/test/stubs/api/StubRecipeAPI.ts
@@ -122,6 +122,18 @@ class StubRecipeAPI implements RecipeAPI {
         return recipe;
     }
 
+    createMany(_options: {
+        itemUuids: string[];
+        craftingSystemId: string;
+        recipeOptionsByItemUuid?: Map<string, RecipeOptions>
+    }): Promise<Recipe[]> {
+        throw new Error(StubRecipeAPI._USE_REAL_INSTEAD_MESSAGE);
+    }
+
+    importCompendium(_options: { craftingSystemId: string; compendiumId: string }): Promise<Recipe[]> {
+        throw new Error(StubRecipeAPI._USE_REAL_INSTEAD_MESSAGE);
+    }
+
 }
 
 export { StubRecipeAPI };


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Fixes item card avatar image rendering in the new app.

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

Looks nice.

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- sets explicit width for the item cards in the fixed size salvage app

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

Before

![image](https://github.com/misterpotts/fabricate/assets/17074386/be7a5fdb-9c1b-4437-8547-93aa3d1e81e8)

After

![image](https://github.com/misterpotts/fabricate/assets/17074386/2ba28d0c-56b0-4640-ad30-dd69800a223a)