### PR TITLE
fix: Default model version setting value

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.10.22
+title: Fabricate 0.10.23
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -12,6 +12,7 @@ import {FabricateUserInterfaceAPI} from "./api/FabricateUserInterfaceAPI";
 import {DefaultFabricatePatreonAPIFactory} from "./patreon/PatreonAPIFactory";
 import {DefaultPatreonFeature} from "./patreon/PatreonFeature";
 import {FabricatePatreonAPI} from "./patreon/FabricatePatreonAPI";
+import {SettingVersion} from "./repository/migration/SettingVersion";
 
 let fabricateAPI: FabricateAPI;
 let fabricateUserInterfaceAPI: FabricateUserInterfaceAPI;
@@ -38,7 +39,7 @@ Hooks.once('ready', async () => {
             [Properties.settings.essences.key, { entities: {}, collections: {} }],
             [Properties.settings.components.key, { entities: {}, collections: {} }],
             [Properties.settings.craftingSystems.key, { entities: {}, collections: {} }],
-            [Properties.settings.modelVersion.key, ""],
+            [Properties.settings.modelVersion.key, SettingVersion.V3],
         ])
     });
 


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

The default value for `modelVersion` is `""` (empty string). This causes a migration to be attempted from V1 to V3 of Fabricate's data model in a fresh install, which fails and prevents the module from loading.

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- Set the default value for `modelVersion` to `V3`

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

![fabricate_bug_2024-02-24_16_53_31](https://github.com/misterpotts/fabricate/assets/17074386/6aecbcf2-5a23-491a-8469-2119bd268693)

