### PR TITLE
Fix: Emdedded system not installed

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Fabricate 0.10.23
+title: Fabricate 0.10.24
 email: matt@misterpotts.uk
 description: >- 
   End user documentation for the Foundry Virtual Tabletop (VTT) Module, "Fabricate".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fabricate",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "description": "A system-agnostic, flexible crafting module for FoundryVT",
   "main": "index.js",
   "type": "module",

--- a/src/scripts/api/SettingMigrationAPI.ts
+++ b/src/scripts/api/SettingMigrationAPI.ts
@@ -46,8 +46,9 @@ interface SettingMigrationAPI {
      *   embedded crafting systems.
      *
      * @async
+     * @param skipInstalled - do not restore embedded systems that are installed, only insert missing systems. Defaults to `false`.
      */
-    restoreEmbeddedCraftingSystems(): Promise<void>;
+    restoreEmbeddedCraftingSystems(skipInstalled?: boolean): Promise<void>;
 
     /**
      * WARNING: This function will remove all user-defined crafting systems and restore the embedded crafting systems to
@@ -128,8 +129,8 @@ class DefaultSettingMigrationAPI implements SettingMigrationAPI {
         }
     }
 
-    async restoreEmbeddedCraftingSystems(): Promise<void> {
-        await this._embeddedCraftingSystemManager.restoreForGameSystem(this._gameSystemId);
+    async restoreEmbeddedCraftingSystems(skipInstalled: boolean = false): Promise<void> {
+        await this._embeddedCraftingSystemManager.restoreForGameSystem(this._gameSystemId, skipInstalled);
     }
 
     async clear(): Promise<void> {

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -102,6 +102,8 @@ Hooks.once(`${Properties.module.id}.ready`, async (fabricateAPI: FabricateAPI) =
         await fabricateAPI.migration.migrateAll();
     }
 
+    await fabricateAPI.migration.restoreEmbeddedCraftingSystems();
+
 });
 
 Hooks.on("deleteItem", async (item: any) => {

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -102,7 +102,7 @@ Hooks.once(`${Properties.module.id}.ready`, async (fabricateAPI: FabricateAPI) =
         await fabricateAPI.migration.migrateAll();
     }
 
-    await fabricateAPI.migration.restoreEmbeddedCraftingSystems();
+    await fabricateAPI.migration.restoreEmbeddedCraftingSystems(true);
 
 });
 

--- a/src/scripts/repository/embedded_systems/EmbeddedCraftingSystemManager.ts
+++ b/src/scripts/repository/embedded_systems/EmbeddedCraftingSystemManager.ts
@@ -67,6 +67,11 @@ class DefaultEmbeddedCraftingSystemManager implements EmbeddedCraftingSystemMana
     }
 
     private async _restoreCraftingSystem(craftingSystem: CraftingSystem): Promise<void> {
+        const systemInstalled = await this._craftingSystemStore.has(craftingSystem.id);
+        if (systemInstalled) {
+            const installedSystem = await this._craftingSystemStore.getById(craftingSystem.id);
+            craftingSystem.isDisabled = installedSystem.isDisabled;
+        }
         await this._craftingSystemStore.insert(craftingSystem);
     }
 

--- a/src/scripts/repository/embedded_systems/EmbeddedCraftingSystemManager.ts
+++ b/src/scripts/repository/embedded_systems/EmbeddedCraftingSystemManager.ts
@@ -73,8 +73,10 @@ class DefaultEmbeddedCraftingSystemManager implements EmbeddedCraftingSystemMana
     private async _restoreEmbeddedCraftingSystemIfNotInstalled(embeddedSystemDefinition: EmbeddedCraftingSystemDefinition): Promise<void> {
         const isInstalled = await this._craftingSystemStore.has(embeddedSystemDefinition.craftingSystem.id);
         if (isInstalled) {
+            console.log(`Fabricate | Embedded crafting system ${embeddedSystemDefinition.craftingSystem.id} is already installed. Skipping installation.`);
             return;
         }
+        console.log(`Fabricate | Installing embedded crafting system ${embeddedSystemDefinition.craftingSystem.id}.`)
         return this._restoreEmbeddedCraftingSystem(embeddedSystemDefinition);
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Fabricate now installs embedded crafting systems on startup if they are not already installed.

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

- Access to AS v1.6 in fresh installs in dnd5e worlds

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- adds `skipInstalled` to `SettingMigrationAPI#restoreEmbeddedCraftingSystems`
- calls `SettingMigrationAPI#restoreEmbeddedCraftingSystems` with`skipInstalled` set to `true` on startup

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->