### PR TITLE
Feat: 298 export import mastercrafted recipes

### DIFF
--- a/src/applications/craftingSystemManagerApp/CraftingSystemEditor.ts
+++ b/src/applications/craftingSystemManagerApp/CraftingSystemEditor.ts
@@ -67,11 +67,10 @@ class CraftingSystemEditor {
     }
 
     async importCraftingSystem(targetCraftingSystem?: CraftingSystem): Promise<void> {
-        const craftingSystemTypeName = this._localization.localize(`${Properties.module.id}.typeNames.craftingSystem.singular`);
-        const importActionHint = this._localization.localize(`${CraftingSystemEditor._dialogLocalizationPath}.importCraftingSystem.hint`);
-        const content = await renderTemplate("templates/apps/import-data.html", {
-            hint1: this._localization.format("DOCUMENT.ImportDataHint1", {document: craftingSystemTypeName}),
-            hint2: this._localization.format("DOCUMENT.ImportDataHint2", {name: importActionHint})
+        const importType = targetCraftingSystem ? "update" : "create";
+        const content = await renderTemplate(`modules/${Properties.module.id}/templates/import-crafting-system.html`, {
+            details: this._localization.localize(`${CraftingSystemEditor._dialogLocalizationPath}.importCraftingSystem.description.${importType}`),
+            fileTypeLabel: this._localization.localize(`${CraftingSystemEditor._dialogLocalizationPath}.importCraftingSystem.labels.fileType`),
         });
         await new Dialog({
             title: this._localization.localize(`${CraftingSystemEditor._dialogLocalizationPath}.importCraftingSystem.title`),

--- a/src/applications/craftingSystemManagerApp/CraftingSystemEditor.ts
+++ b/src/applications/craftingSystemManagerApp/CraftingSystemEditor.ts
@@ -149,14 +149,39 @@ class CraftingSystemEditor {
     }
 
     public async exportCraftingSystem(craftingSystem: CraftingSystem) {
-        // Todo - add a dialog to allow the user to choose the export format
-        const exportData = await this._fabricateAPI.dataExchangeAPI.fabricate.export(craftingSystem.id);
-        const fileContents = JSON.stringify(exportData, null, 2);
-        //@ts-ignore todo: figure out why String doesn't have a slugify method with the current tsconfig
-        const fileName = `fabricate-crafting-system-${craftingSystem.details.name.slugify()}.json`;
-        saveDataToFile(fileContents, "application/json", fileName);
-        const message = this._localization.format(`${CraftingSystemEditor._dialogLocalizationPath}.exportCraftingSystem.success`, { systemName: craftingSystem.details.name, fileName });
-        ui.notifications.info(message);
+        await new Dialog({
+            title: this._localization.localize(`${CraftingSystemEditor._dialogLocalizationPath}.exportCraftingSystem.title`),
+            content: this._localization.localize(`${CraftingSystemEditor._dialogLocalizationPath}.exportCraftingSystem.description`),
+            buttons: {
+                fabricate: {
+                    label: "Fabricate",
+                    callback: async () => {
+                        const exportData = await this._fabricateAPI.dataExchangeAPI.fabricate.export(craftingSystem.id);
+                        const fileContents = JSON.stringify(exportData, null, 2);
+                        //@ts-ignore todo: figure out why String doesn't have a slugify method with the current tsconfig
+                        const fileName = `fabricate-crafting-system-${craftingSystem.details.name.slugify()}.json`;
+                        saveDataToFile(fileContents, "application/json", fileName);
+                        const message = this._localization.format(`${CraftingSystemEditor._dialogLocalizationPath}.exportCraftingSystem.success`, { systemName: craftingSystem.details.name, fileName });
+                        ui.notifications.info(message);
+                    }
+                },
+                masterCrafted: {
+                    label: "MasterCrafted",
+                    callback: async () => {
+                        const exportData = await this._fabricateAPI.dataExchangeAPI.masterCrafted.export(craftingSystem.id);
+                        const fileContents = JSON.stringify(exportData, null, 2);
+                        //@ts-ignore todo: figure out why String doesn't have a slugify method with the current tsconfig
+                        const fileName = `mastercrafted-recipe-book-${exportData.name.slugify()}.json`;
+                        saveDataToFile(fileContents, "application/json", fileName);
+                        const message = this._localization.format(`${CraftingSystemEditor._dialogLocalizationPath}.exportCraftingSystem.success`, { systemName: craftingSystem.details.name, fileName });
+                        ui.notifications.info(message);
+                    }
+                },
+            },
+            default: "fabricate",
+        }, {}).render(true);
+
+
     }
 
     async duplicateCraftingSystem(sourceCraftingSystem: CraftingSystem): Promise<CraftingSystem> {

--- a/src/applications/craftingSystemManagerApp/CraftingSystemNavbar.svelte
+++ b/src/applications/craftingSystemManagerApp/CraftingSystemNavbar.svelte
@@ -17,8 +17,8 @@
         $selectedCraftingSystem = await craftingSystemEditor.createNewCraftingSystem();
     }
 
-    async function importCraftingSystem(targetCraftingSystemId) {
-        await craftingSystemEditor.importCraftingSystem(targetCraftingSystemId);
+    async function importCraftingSystem() {
+        await craftingSystemEditor.importCraftingSystem();
     }
 
 </script>

--- a/src/public/lang/en.json
+++ b/src/public/lang/en.json
@@ -451,11 +451,13 @@
         "saveCraftingSystem": {
           "success": "The Crafting System {systemName} was successfully updated."
         },
-        "exportCraftingSystem": {
-          "success": "The Crafting System {systemName} was successfully exported to {fileName}."
-        },
         "duplicateCraftingSystem": {
           "complete": "Duplicated {sourceSystemName} as {duplicatedSystemName}."
+        },
+        "exportCraftingSystem": {
+          "success": "The Crafting System {systemName} was successfully exported to {fileName}.",
+          "title": "Export Crafting System",
+          "description": "Export this Crafting System definition to a JSON file. You can export the data in Fabricate's external format, or in a format compatible with the MasterCrafted module. Which format would you like to use?"
         },
         "importCraftingSystem": {
           "title": "Import Crafting System",
@@ -473,8 +475,7 @@
           "errors": {
             "invalidFileType": "Invalid file type. Fabricate accepts \"fabricate\" or \"mastercrafted\" when importing Crafting Systems.",
             "noFileUploaded": "You must select a file to upload",
-            "couldNotParseFile": "Unable to parse JSON file.",
-            "targetSystemNotFound": "Could not import Crafting System definition for {systemName}. {systemName} doesn't seem to exist, which is really strange. This should never happen."
+            "couldNotParseFile": "Unable to parse JSON file."
           },
           "success": "Successfully Imported the {systemName} Crafting System"
         }

--- a/src/public/lang/en.json
+++ b/src/public/lang/en.json
@@ -245,6 +245,11 @@
         }
       }
     },
+    "CraftingSystemDataExchanger": {
+      "errors": {
+        "importIdMismatch": "Cannot import Crafting System definition for {systemName}. The ID in the uploaded file does not match that of {systemName}. Wanted {expectedId}, but got {actualId}. Perhaps you uploaded the wrong file, or meant to use the Import new button below?"
+      }
+    },
     "CraftingSystemManagerApp": {
       "title": "Fabricate | Crafting System Manager",
       "tabs": {
@@ -466,9 +471,9 @@
             "cancel": "Cancel"
           },
           "errors": {
+            "invalidFileType": "Invalid file type. Fabricate accepts \"fabricate\" or \"mastercrafted\" when importing Crafting Systems.",
             "noFileUploaded": "You must select a file to upload",
             "couldNotParseFile": "Unable to parse JSON file.",
-            "importIdMismatch": "Cannot import Crafting System definition for {systemName}. The ID in the uploaded file does not match that of {systemName}. Wanted {expectedId}, but got {actualId}. Perhaps you uploaded the wrong file, or meant to use the Import new button below?",
             "targetSystemNotFound": "Could not import Crafting System definition for {systemName}. {systemName} doesn't seem to exist, which is really strange. This should never happen."
           },
           "success": "Successfully Imported the {systemName} Crafting System"

--- a/src/public/lang/en.json
+++ b/src/public/lang/en.json
@@ -454,7 +454,13 @@
         },
         "importCraftingSystem": {
           "title": "Import Crafting System",
-          "hint": "the Crafting System with the same ID as the Crafting System in the uploaded document, or create a new one,",
+          "description": {
+            "update": "Re-import this Crafting System definition by uploading a JSON file. This will overwrite the existing Crafting System. This operation cannot be undone.",
+            "create": "Import a new Crafting System from a JSON file. This will create a new Crafting System matching the imported definition."
+          },
+          "labels": {
+            "fileType": "File Type"
+          },
           "buttons": {
             "import": "Import",
             "cancel": "Cancel"

--- a/src/public/templates/import-crafting-system.html
+++ b/src/public/templates/import-crafting-system.html
@@ -2,7 +2,7 @@
     <p class="notes">{{details}}</p>
     <div class="form-group">
         <label for="data">Source Data</label>
-        <input type="file" name="data" accept=".json">
+        <input type="file" name="data" id="data" accept=".json">
     </div>
     <div class="form-group">
         <label for="fileType">{{fileTypeLabel}}</label>

--- a/src/public/templates/import-crafting-system.html
+++ b/src/public/templates/import-crafting-system.html
@@ -1,0 +1,14 @@
+<form autocomplete="off" onsubmit="preventDefault()">
+    <p class="notes">{{details}}</p>
+    <div class="form-group">
+        <label for="data">Source Data</label>
+        <input type="file" name="data" accept=".json">
+    </div>
+    <div class="form-group">
+        <label for="fileType">{{fileTypeLabel}}</label>
+        <select name="fileType" id="fileType">
+            <option value="fabricate">Fabricate Crafting System Definition</option>
+            <option value="mastercrafted">MasterCrafted Recipe Book</option>
+        </select>
+    </div>
+</form>

--- a/src/scripts/api/CraftingSystemDataExchanger.ts
+++ b/src/scripts/api/CraftingSystemDataExchanger.ts
@@ -1,0 +1,413 @@
+import {CraftingSystemData} from "./FabricateAPI";
+import {FabricateExportModel} from "../repository/import/FabricateExportModel";
+import {RecipeAPI} from "./RecipeAPI";
+import {EssenceAPI} from "./EssenceAPI";
+import {ComponentAPI} from "./ComponentAPI";
+import {CraftingSystemAPI} from "./CraftingSystemAPI";
+import {LocalizationService} from "../../applications/common/LocalizationService";
+import {NotificationService} from "../foundry/NotificationService";
+import Properties from "../Properties";
+import {V2Component, V2CraftingSystem, V2Essence, V2Recipe} from "../repository/migration/V2SettingsModel";
+import {CraftingSystem} from "../crafting/system/CraftingSystem";
+
+const dialogLocalizationPath = `${Properties.module.id}.CraftingSystemDataExchanger`;
+
+/**
+ * A data exchanger for importing and exporting Crafting System data in a given format.
+ *
+ * @typeParam E - The type of the external data
+ */
+interface CraftingSystemDataExchanger<E> {
+
+    notifications: NotificationService;
+
+    /**
+     * Imports the given data into Fabricate as a Crafting System.
+     *
+     * @async
+     * @param importData - The data to import.
+     * @param targetCraftingSystem - The optional Crafting System to import the data into. If not provided, a new Crafting
+     * System will be created.
+     * @returns {Promise<O>} A Promise that resolves to an object containing the imported data.
+     */
+    import(importData: E, targetCraftingSystem?: CraftingSystem): Promise<CraftingSystemData>;
+
+    /**
+     * Exports a complete Crafting System from Fabricate for the given Crafting System ID in the
+     *
+     * @async
+     * @returns {Promise<I>} A Promise that resolves to the exported data.
+     */
+    export(craftingSystemId: string): Promise<E>;
+
+}
+
+export {CraftingSystemDataExchanger};
+
+interface FabricateDataExchanger extends CraftingSystemDataExchanger<FabricateExportModel> {}
+
+export {FabricateDataExchanger};
+
+class DefaultFabricateDataExchanger implements FabricateDataExchanger {
+
+    private readonly recipeAPI: RecipeAPI;
+    private readonly essenceAPI: EssenceAPI;
+    private readonly componentAPI: ComponentAPI;
+    private readonly craftingSystemAPI: CraftingSystemAPI;
+    private readonly localizationService: LocalizationService;
+    private readonly notificationService: NotificationService;
+
+    constructor({
+        recipeAPI,
+        essenceAPI,
+        componentAPI,
+        craftingSystemAPI,
+        localizationService,
+        notificationService,
+    }: {
+        recipeAPI: RecipeAPI;
+        essenceAPI: EssenceAPI;
+        componentAPI: ComponentAPI;
+        craftingSystemAPI: CraftingSystemAPI;
+        localizationService: LocalizationService;
+        notificationService: NotificationService;
+    }) {
+        this.recipeAPI = recipeAPI;
+        this.essenceAPI = essenceAPI;
+        this.componentAPI = componentAPI;
+        this.craftingSystemAPI = craftingSystemAPI;
+        this.localizationService = localizationService;
+        this.notificationService = notificationService;
+    }
+
+    get notifications(): NotificationService {
+        return this.notificationService;
+    }
+
+    async import(importData: FabricateExportModel, targetCraftingSystem?: CraftingSystem): Promise<CraftingSystemData> {
+
+        // If a target Crafting System is provided, ensure that the Crafting System ID in the import data matches the target.
+        if (targetCraftingSystem && (targetCraftingSystem.id !== importData.craftingSystem.id)) {
+            const message = this.localizationService.format(`${dialogLocalizationPath}.errors.importIdMismatch`, {
+                systemName: targetCraftingSystem.details.name,
+                expectedId: targetCraftingSystem.id,
+                actualId: importData.craftingSystem.id,
+            })
+            ui.notifications.error(message);
+            throw new Error(message);
+        }
+
+        // Upgrade the import model if necessary and validate the import data.
+        importData = this.upgradeV1ImportData(importData);
+        await this.validateImportData(importData);
+
+        try {
+            const importedCraftingSystem = await this.craftingSystemAPI.insert(importData.craftingSystem);
+            const importedEssences = await this.essenceAPI.insertMany(importData.essences);
+            const importedComponents = await this.componentAPI.insertMany(importData.components);
+            const importedRecipes = await this.recipeAPI.insertMany(importData.recipes);
+            const message = this.localizationService.format(
+                `${Properties.module.id}.settings.craftingSystem.import.success`,
+                {
+                    systemName: importedCraftingSystem.details.name,
+                    essenceCount: importedEssences.length,
+                    componentCount: importedComponents.length,
+                    recipeCount: importedRecipes.length,
+                }
+            );
+            this.notificationService.info(message);
+            return {
+                craftingSystem: importedCraftingSystem,
+                essences: importedEssences,
+                components: importedComponents,
+                recipes: importedRecipes,
+            }
+        } catch (e: any) {
+            const message = this.localizationService.format(
+                `${Properties.module.id}.settings.craftingSystem.import.failure`,
+                { systemName: importData?.craftingSystem?.details?.name, cause: e.message }
+            );
+            this.notificationService.error(message);
+        }
+
+    }
+
+    private async validateImportData(importData: FabricateExportModel) {
+
+        const errors: string[] = [];
+
+        if (!importData) {
+            errors.push(this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.invalidData.noData`));
+        }
+
+        if (!importData.version || typeof importData.version !== "string") {
+            errors.push(this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.invalidData.noVersion`));
+        }
+
+        if (!importData.craftingSystem || typeof importData.craftingSystem !== "object") {
+            errors.push(this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.invalidData.noCraftingSystem`));
+        }
+
+        if (!importData.essences || !Array.isArray(importData.essences)) {
+            errors.push(this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.invalidData.noEssences`));
+        }
+
+        if (!importData.components || !Array.isArray(importData.components)) {
+            errors.push(this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.invalidData.noComponents`));
+        }
+
+        if (!importData.recipes || !Array.isArray(importData.recipes)) {
+            errors.push(this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.invalidData.noRecipes`));
+        }
+
+        if (errors.length > 0) {
+            const message = this.localizationService.format(`${Properties.module.id}.settings.craftingSystem.import.invalidData.summary`, { errors: errors.join(', ') });
+            this.notificationService.error(message);
+            throw new Error(message);
+        }
+
+    }
+
+    private upgradeV1ImportData(importData: FabricateExportModel) {
+
+        if (importData?.version === "V2") {
+            return importData;
+        }
+
+        if (!importData || !("parts" in importData)) {
+            const message = this.localizationService.localize(`${Properties.module.id}.settings.craftingSystem.import.upgrade.failure`);
+            this.notificationService.error(message);
+            throw new Error(message);
+        }
+
+        const legacyImportData: V2CraftingSystem = importData as unknown as V2CraftingSystem;
+        const upgradedImportData: FabricateExportModel = {
+            version: "V2",
+            craftingSystem: {
+                id: legacyImportData.id,
+                details: {
+                    name: legacyImportData.details.name,
+                    author: legacyImportData.details.author,
+                    summary: legacyImportData.details.summary,
+                    description: legacyImportData.details.description,
+                },
+                disabled: legacyImportData.enabled === false,
+            },
+            essences: Object.keys(legacyImportData.parts.essences).map(essenceId => {
+                const legacyEssence: V2Essence = legacyImportData.parts.essences[essenceId];
+                return {
+                    id: essenceId,
+                    craftingSystemId: legacyImportData.id,
+                    disabled: false,
+                    ...legacyEssence,
+                }
+            }),
+            components: Object.keys(legacyImportData.parts.components).map(componentId => {
+                const legacyComponent: V2Component = legacyImportData.parts.components[componentId];
+                return {
+                    id: componentId,
+                    craftingSystemId: legacyImportData.id,
+                    disabled: legacyComponent.disabled,
+                    essences: legacyComponent.essences,
+                    itemUuid: legacyComponent.itemUuid,
+                    salvageOptions: Object.keys(legacyComponent.salvageOptions).map(salvageOptionId => {
+                        const legacySalvageOption = legacyComponent.salvageOptions[salvageOptionId];
+                        return {
+                            id: salvageOptionId,
+                            name: salvageOptionId,
+                            catalysts: {},
+                            results: legacySalvageOption
+                        }
+                    }),
+                }
+            }),
+            recipes: Object.keys(legacyImportData.parts.recipes).map(recipeId => {
+                const legacyRecipe: V2Recipe = legacyImportData.parts.recipes[recipeId];
+                return {
+                    id: recipeId,
+                    craftingSystemId: legacyImportData.id,
+                    disabled: legacyRecipe.disabled,
+                    itemUuid: legacyRecipe.itemUuid,
+                    requirementOptions: Object.keys(legacyRecipe.ingredientOptions).map(ingredientOptionId => {
+                        const legacyIngredientOption = legacyRecipe.ingredientOptions[ingredientOptionId];
+                        return {
+                            id: ingredientOptionId,
+                            name: ingredientOptionId,
+                            ingredients: legacyIngredientOption.ingredients,
+                            catalysts: legacyIngredientOption.catalysts,
+                            essences: legacyRecipe.essences,
+                        }
+                    }),
+                    resultOptions: Object.keys(legacyRecipe.resultOptions).map(resultOptionId => {
+                        const legacyResultOption = legacyRecipe.resultOptions[resultOptionId];
+                        return {
+                            id: resultOptionId,
+                            name: resultOptionId,
+                            results: legacyResultOption,
+                        }
+                    }),
+                }
+            })
+        };
+        return upgradedImportData;
+    }
+
+    async export(craftingSystemId: string): Promise<FabricateExportModel> {
+
+        const craftingSystem = await this.craftingSystemAPI.getById(craftingSystemId);
+
+        if (!craftingSystem) {
+            const message = this.localizationService.format(
+                `${Properties.module.id}.settings.craftingSystem.export.craftingSystemNotFound`,
+                { craftingSystemId }
+            );
+            this.notificationService.error(message);
+            throw new Error(message);
+        }
+
+        const essences = await this.essenceAPI.getAllByCraftingSystemId(craftingSystemId);
+        const components = await this.componentAPI.getAllByCraftingSystemId(craftingSystemId);
+        const recipes = await this.recipeAPI.getAllByCraftingSystemId(craftingSystemId);
+
+        return {
+            version: "V2",
+            craftingSystem: {
+                id: craftingSystem.id,
+                details: {
+                    name: craftingSystem.details.name,
+                    summary: craftingSystem.details.summary,
+                    description: craftingSystem.details.description,
+                    author: craftingSystem.details.author,
+                },
+                disabled: craftingSystem.isDisabled,
+            },
+            essences: Array.from(essences.values()).map(essence => essence.toJson()),
+            components: Array.from(components.values()).map(component => {
+                const componentJson = component.toJson();
+                return {
+                    ...componentJson,
+                    salvageOptions: Object.values(componentJson.salvageOptions),
+                }
+            }),
+            recipes: Array.from(recipes.values()).map(recipe => {
+                const recipeJson = recipe.toJson();
+                return {
+                    ...recipeJson,
+                    requirementOptions: Object.values(recipeJson.requirementOptions),
+                    resultOptions: Object.values(recipeJson.resultOptions),
+                }
+            })
+        };
+    }
+
+}
+
+export {DefaultFabricateDataExchanger};
+
+// =====================================================================================================================
+// MasterCrafted Type Definitions
+// =====================================================================================================================
+
+interface IngredientMasterCrafted {
+    id: string;
+    name?: string;
+    components?: ComponentMasterCrafted[];
+    recipe?: RecipeMasterCrafted;
+}
+
+interface ProductMasterCrafted {
+    id: string;
+    name: string;
+    components: ComponentMasterCrafted[];
+}
+
+interface ComponentMasterCrafted {
+    id?: string;
+    uuid?: string;
+    quantity?: number;
+    name?: string;
+}
+
+interface RecipeMasterCrafted {
+    id?: string;
+    name?: string;
+    description?: string;
+    time?: number;
+    macroName?: string;
+    recipeBook?: RecipeBookMasterCrafted;
+    ingredients?: IngredientMasterCrafted[];
+    products?: ProductMasterCrafted[];
+    tools?: string[];
+    sound?: string;
+    ownership?: Record<string, unknown>;
+    ingredientsInspection?: 0 | 1;
+    productInspection?: 0 | 1;
+    img?: string;
+}
+
+interface RecipeBookMasterCrafted {
+    id: string;
+    name: string;
+    description: string;
+    recipes?: RecipeMasterCrafted[];
+    tools?: string[];
+    sound?: string;
+    ownership?: Record<string, unknown>;
+    ingredientsInspection?: 0 | 1;
+    productInspection?: 0 | 1;
+    img: string;
+}
+
+export {IngredientMasterCrafted, ProductMasterCrafted, ComponentMasterCrafted, RecipeMasterCrafted, RecipeBookMasterCrafted};
+
+interface MasterCraftedDataExchanger extends CraftingSystemDataExchanger<RecipeBookMasterCrafted> {}
+
+export {MasterCraftedDataExchanger};
+
+class DefaultMasterCraftedDataExchanger implements MasterCraftedDataExchanger {
+
+    private readonly recipeAPI: RecipeAPI;
+    private readonly essenceAPI: EssenceAPI;
+    private readonly componentAPI: ComponentAPI;
+    private readonly craftingSystemAPI: CraftingSystemAPI;
+    private readonly localizationService: LocalizationService;
+    private readonly notificationService: NotificationService;
+
+    constructor({
+        recipeAPI,
+        essenceAPI,
+        componentAPI,
+        craftingSystemAPI,
+        localizationService,
+        notificationService,
+    }: {
+        recipeAPI: RecipeAPI;
+        essenceAPI: EssenceAPI;
+        componentAPI: ComponentAPI;
+        craftingSystemAPI: CraftingSystemAPI;
+        localizationService: LocalizationService;
+        notificationService: NotificationService;
+    }) {
+        this.recipeAPI = recipeAPI;
+        this.essenceAPI = essenceAPI;
+        this.componentAPI = componentAPI;
+        this.craftingSystemAPI = craftingSystemAPI;
+        this.localizationService = localizationService;
+        this.notificationService = notificationService;
+    }
+
+    get notifications(): NotificationService {
+        return this.notificationService;
+    }
+
+    async import(_importData: RecipeBookMasterCrafted): Promise<CraftingSystemData> {
+        throw new Error("Method not implemented.");
+    }
+
+    async export(_craftingSystemId: string): Promise<RecipeBookMasterCrafted> {
+        throw new Error("Method not implemented.");
+    }
+
+}
+
+export {DefaultMasterCraftedDataExchanger};

--- a/src/scripts/api/DataExchangeAPI.ts
+++ b/src/scripts/api/DataExchangeAPI.ts
@@ -1,0 +1,66 @@
+import {FabricateDataExchanger, MasterCraftedDataExchanger} from "./CraftingSystemDataExchanger";
+
+/**
+ * The API for data exchange to and from external formats.
+ */
+interface DataExchangeAPI {
+
+    /**
+     * The API for exchanging data in Fabricate's external format.
+     */
+    fabricate: FabricateDataExchanger;
+
+    /**
+     * The API for exchanging data in MasterCrafted's external format.
+     */
+    masterCrafted: MasterCraftedDataExchanger;
+
+    /**
+     * Downloads a copy of all Fabricate data as a JSON file. This function is used for debugging and troubleshooting.
+     * If you want to export data from Fabricate for use in another Foundry VTT world, use {@link FabricateAPI#export}
+     */
+    downloadData(): void;
+
+}
+
+export {DataExchangeAPI};
+
+class DefaultDataExchangeAPI implements DataExchangeAPI {
+
+    private readonly _fabricateDataExchanger: FabricateDataExchanger;
+    private readonly _masterCraftedDataExchanger: MasterCraftedDataExchanger;
+
+    constructor({
+        fabricateDataExchanger,
+        masterCraftedDataExchanger
+    }: {
+        fabricateDataExchanger: FabricateDataExchanger,
+        masterCraftedDataExchanger: MasterCraftedDataExchanger
+    }) {
+        this._fabricateDataExchanger = fabricateDataExchanger;
+        this._masterCraftedDataExchanger = masterCraftedDataExchanger;
+    }
+
+    get fabricate(): FabricateDataExchanger {
+        return this._fabricateDataExchanger;
+    }
+
+    get masterCrafted(): MasterCraftedDataExchanger {
+        return this._masterCraftedDataExchanger;
+    }
+
+    downloadData(): void {
+        const allFabricateSettingValues = Array.from(game.settings.storage.get("world").values())
+            .filter((setting: any) => setting.key.search(new RegExp("fabricate", "i")) >= 0);
+        const fileContents = JSON.stringify(allFabricateSettingValues, null, 2);
+        const dateTime = new Date();
+        const postfix = dateTime.toISOString()
+            .replace(/:\s*/g, "-")
+            .replace(".", "-");
+        const fileName = `fabricate-data-extract-${postfix}.json`;
+        saveDataToFile(fileContents, "application/json", fileName);
+    }
+
+}
+
+export {DefaultDataExchangeAPI};

--- a/src/scripts/api/FabricateAPIFactory.ts
+++ b/src/scripts/api/FabricateAPIFactory.ts
@@ -2,7 +2,7 @@ import {DefaultGameProvider, GameProvider} from "../foundry/GameProvider";
 import {DefaultUIProvider, UIProvider} from "../foundry/UIProvider";
 import {DefaultDocumentManager, DocumentManager} from "../foundry/DocumentManager";
 import {DefaultIdentityFactory, IdentityFactory} from "../foundry/IdentityFactory";
-import {DefaultLocalizationService} from "../../applications/common/LocalizationService";
+import {DefaultLocalizationService, LocalizationService} from "../../applications/common/LocalizationService";
 import {DefaultSettingMigrationAPI, SettingMigrationAPI} from "./SettingMigrationAPI";
 import {CraftingSystemAPI, DefaultCraftingSystemAPI} from "./CraftingSystemAPI";
 import {DefaultNotificationService} from "../foundry/NotificationService";
@@ -45,6 +45,8 @@ import {DefaultInventoryFactory} from "../actor/InventoryFactory";
 import {
     DefaultComponentSelectionStrategyFactory
 } from "../crafting/component/ComponentSelectionStrategy";
+import {DataExchangeAPI, DefaultDataExchangeAPI} from "./DataExchangeAPI";
+import {DefaultFabricateDataExchanger, DefaultMasterCraftedDataExchanger} from "./CraftingSystemDataExchanger";
 
 interface FabricateAPIFactory {
 
@@ -156,6 +158,15 @@ class DefaultFabricateAPIFactory implements FabricateAPIFactory {
             this.gameProvider
         );
 
+        const dataExchangeAPI = this.makeDataExchangeAPI(
+            recipeAPI,
+            essenceAPI,
+            componentAPI,
+            craftingSystemAPI,
+            localizationService,
+            this.uiProvider
+        );
+
         return new DefaultFabricateAPI({
             recipeAPI,
             essenceAPI,
@@ -165,8 +176,35 @@ class DefaultFabricateAPIFactory implements FabricateAPIFactory {
             settingMigrationAPI,
             localizationService,
             notificationService: new DefaultNotificationService(this.uiProvider),
+            dataExchangeAPI
         });
 
+    }
+
+    private makeDataExchangeAPI(recipeAPI: RecipeAPI,
+                                essenceAPI: EssenceAPI,
+                                componentAPI: ComponentAPI,
+                                craftingSystemAPI: CraftingSystemAPI,
+                                localizationService: LocalizationService,
+                                uiProvider: UIProvider): DataExchangeAPI {
+        return new DefaultDataExchangeAPI({
+            fabricateDataExchanger: new DefaultFabricateDataExchanger({
+                recipeAPI,
+                essenceAPI,
+                componentAPI,
+                craftingSystemAPI,
+                localizationService,
+                notificationService: new DefaultNotificationService(uiProvider)
+            }),
+            masterCraftedDataExchanger: new DefaultMasterCraftedDataExchanger({
+                recipeAPI,
+                essenceAPI,
+                componentAPI,
+                craftingSystemAPI,
+                localizationService,
+                notificationService: new DefaultNotificationService(uiProvider)
+            })
+        });
     }
 
     private makeSettingManger<T>(settingKey: string): SettingManager<T> {

--- a/test/FabricateAPI.test.ts
+++ b/test/FabricateAPI.test.ts
@@ -540,7 +540,7 @@ describe("Export and import data", () => {
         const underTest = fabricateAPIFactory.make();
 
         const alchemistsSupplies = new AlchemistsSuppliesV16SystemDefinition();
-        const exportData = await underTest.export(alchemistsSupplies.craftingSystem.id);
+        const exportData = await underTest.dataExchangeAPI.fabricate.export(alchemistsSupplies.craftingSystem.id);
 
         expect(exportData).not.toBeNull();
         expect(exportData.version).toBe("V2");

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,6 +1,6 @@
 declare interface DialogButtonConfig {
 
-    icon: string;
+    icon?: string;
 
     label: string;
 


### PR DESCRIPTION
## Description

<!-- Describe the changes you made and why you made them -->
<!-- If you have resolved an open Issue, please link to it here (e.g. "Closes #487") -->
<!-- If you are fixing a bug that doesn't have an associated Issue, please include the steps to reproduce the bug so that your fix can be tested -->

Building on https://github.com/misterpotts/fabricate/pull/322 an addressing my own comments, I've created a skeleton structure for importing and exporting Mastercrafted Recipe books.

## Benefit(s)

<!-- Describe the benefits of your changes: who does the change impact and how, why should this change be accepted, etc. -->

- Easier time migrating from one module to the other 

## Changes in this PR

<!-- Describe the changes you made in this PR, and how they address the Issue or benefit the module -->
<!-- Ideally, include them as a bulleted list below, e.g. -->
<!-- - Added a new setting to allow users to configure "X" -->
<!-- - Removed an incorrect test assertion about "K" in test "Y" -->

- Introduce `DataExchangeAPI` t extract import/export from the `FabricateAPI`
- Implement a MasterCrafted (currently no-op) and Fabricate Data Exchanger
- Add a prompt on import to select the data import format
- Add a prompton export to select the data export format

## Screenshots (if appropriate)

<!-- If your changes include a visual component, please include a screenshot or screenshots here -->

Import dialogue

![import-mastercrafted-dialogue](https://github.com/misterpotts/fabricate/assets/17074386/f8abfd08-f7bc-4f92-9d6a-978966230e3f)

Export dialogue

![export-mastercrafted-dialogue](https://github.com/misterpotts/fabricate/assets/17074386/541e336f-cf2a-418f-b7b1-1b9c3bfe6cf2)
